### PR TITLE
Add option for a 'free' Gifted Blade for Soulknives

### DIFF
--- a/COM_3PPPack_DSP_Mechanics.user
+++ b/COM_3PPPack_DSP_Mechanics.user
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document signature="Hero Lab Data">
+  <thing id="mechHPGiBl" name="High Psionics Gifted Blade Mechanic" compset="Mechanics">
+    <usesource source="pPsiHPGB"/>
+    <tag group="Custom" tag="PsiHPGiBl" name="The user&apos;s enabled the free Gifted Blade option and has soulknife levels."/>
+    <bootstrap thing="arPUGiftBl">
+      <containerreq phase="GlobalTest" priority="10050">Custom.PsiHPGiBl</containerreq>
+      </bootstrap>
+    <eval phase="First" priority="10000" index="2"><![CDATA[~ For this rules variant, Gifted Blade is "free"
+~ That is to say, it doesn't replace anything
+perform hero.childfound[arPUGiftBl].delete[AbReplace.cSknPsyStr]
+
+~ We change the name to make it clear this variant is in use
+hero.childfound[arPUGiftBl].field[livename].text = "High Psionics Gifted Blade"]]></eval>
+    <eval phase="GlobalTest" priority="10000"><![CDATA[~ If Soulknife found then apply tag, which triggers archetype bootstrap
+doneif (hero.haschild[BaseClHelp, "thingid.cHelpSkn"] = 0)
+perform hero.assign[Custom.PsiHPGiBl]]]></eval>
+    </thing>
+  </document>

--- a/COM_Source_210 - Dreamscarred Press.1st
+++ b/COM_Source_210 - Dreamscarred Press.1st
@@ -23,6 +23,23 @@
     description="Dreamscarred Press Path of War Pathfinder Books.">
     </source>
 
+  <source
+    id="pPsionics"
+    name="Psionics"
+    selectable="no"
+    parent="pDscar"
+    sortorder="10"
+    description="Psionics rules for Pathfinder inputted by the HL Community.">
+    </source>
+
+  <source
+    id="pPsiHiPsi"
+    name="High Psionics campaign options"
+    selectable="no"
+    parent="pPsionics"
+    sortorder="10"
+    description="Enables high psionics rules variants for class and archetype progressions.">
+    </source>
 
   <!-- ============================================== -->
   <!-- New Child Psionic Sources                      -->
@@ -31,9 +48,21 @@
     id="pPsiUn"
     name="DSP - Ultimate Psionics"
     selectable="yes"
-    parent="pDscar"
+    parent="pPsionics"
     sortorder="10"
     description="Psionics rules for Pathfinder inputted by the HL Community.">
+    </source>
+
+  <!-- ============================================== -->
+  <!-- New Child High Psionics options                -->
+  <!-- ============================================== -->
+  <source
+    id="pPsiHPGB"
+    name="Free Gifted Blade for soulknives"
+    selectable="yes"
+    parent="pPsiHiPsi"
+    sortorder="10"
+    description="Gives all soulknives the benefits of the Gifted Blade archetype for free.">
     </source>
 
   <!-- ============================================== -->


### PR DESCRIPTION
This is something that's appeared printed in a few different DSP books (and not in Ultimate Psionics itself), so I added it as a separate "generic DSP" mechanics file. Feel free to change that up if it will make things more practical, but I do plan to also submit some other small psionics books from DSP in the near future, so just labeling everything under Ultimate Psionics probably isn't a good idea.

The actual impact here is pretty simple:
- If the source is selected, the mechanic bootstraps the Gifted Blade if the Soulknife class is on the character
- It removes the `AbReplace.cSknPsyStr` tag from the Gifted Blade archetype 
- It also changes the `livename` to "High Psionics Gifted Blade" to make things clearer on character sheets/exports

This also reorganizes the nesting of settings slightly, so there's a parent "Psionics" unselectable item that Ultimate Psionics and the rules variants live under.