### PR TITLE
Test (#110)

### DIFF
--- a/COM_3PPPack_UltimatePsionics - Classes (Psion).user
+++ b/COM_3PPPack_UltimatePsionics - Classes (Psion).user
@@ -264,21 +264,32 @@
       <autotag group="ClSpecWhen" tag="2"/>
       </bootstrap>
     </thing>
-  <thing id="cPsiSumCal" name="Summoner&apos;s Call" description="At 2nd level, if you maintain focus when manifesting a power of the creation subdiscipline, the duration is increased by 1 round plus 1 round for every four psion levels. In addition, your astral constructs gain an additional menu option of the highest menu available when you manifest the power." compset="ClSpecial">
+  <thing id="cPsiSumCal" name="Summoner&apos;s Call" description="At 2nd level, if you maintain focus when manifesting a power of the creation subdiscipline, the duration is increased by 1 round plus 1 round for every four psion levels. In addition, your astral constructs gain an additional menu option of the highest menu available when you manifest the power.{br}{br}{b}Note:{/b} This ability is scripted to only work with Astral Constructs added through the Other tab" compset="ClSpecial">
     <tag group="AbilType" tag="Extra"/>
     <tag group="abAction" tag="PUManFocus"/>
-    <eval phase="Render" priority="1000"><![CDATA[
-      var v_focus as number
-      call PUPsiFocus
-      ~ If Not psionically focused get out now
-      doneif (v_focus <> 1)
+    <eval phase="PreLevel" priority="10000" index="1"><![CDATA[
+      ~ We're earlier than the normal test for whether we've reached the correct level, so we'll recreate that test here
+      doneif (root.linkage[table].field[cTotalLev].value + field[xExtraLev].value + field[xEffectLev].value < tagvalue[ClSpecWhen.?])
 
-      ~the bonus rounds for the creation subdiscipline 1+level/4
-      var bonus as number
-      bonus = 1+(#levelcount[Psion]/4)
-      bonus = round(bonus,0,-1)
+      ~ Find all Astral Construct minions and assign a helper
+      ~ tag to let the Astral Construct increase the allowed
+      ~ menu choices
+      foreach pick in hero from OnlyMinion where "gType.PUAstrCons"
+        perform eachpick.minion.assign[Psionics.AstConMenu]
+      nexteach]]></eval>
+    <eval phase="Final" priority="50000" index="2"><![CDATA[
+      ~ If we're not shown, just get out now
+      doneif (tagis[Helper.ShowSpec] <> 1)
+      ~ if we've been disabled, get out now
+      doneif (tagis[Helper.SpcDisable] <> 0)
 
-      field[abSumm].text = "Manifestations from the creation subdiscipline last an additional " & bonus & "rounds."]]></eval>
+      ~ Calculate the bonus rounds as 1+level/4
+      field[abDuration].value = round(#levelcount[Psion]/4,0,-1) + 1
+
+      field[abSumm].text = "Manifestations from the creation subdiscipline last an additional " & field[abDuration].value & " rounds."
+
+      field[livename].text = field[thingname].text & " (" & field[abDuration].value & " rds)"
+      ]]></eval>
     </thing>
   <thing id="cPUIConstr" name="Improved Constructs" description="At 8th level, you gain your choice of the Advanced Construct* or Boost Construct feat as a bonus feat. If you already have one of the feats, you gain the other instead. If you already possess both feats, you gain a bonus psionic feat of your choice. You must meet any applicable prerequisites to select the feat.\n\n{b}Note:{/b} Not Scripted yet." compset="ClSpecial">
     <comment>Stub</comment>

--- a/COM_3PPPack_UltimatePsionics - Feats.user
+++ b/COM_3PPPack_UltimatePsionics - Feats.user
@@ -79,15 +79,25 @@
     <tag group="Helper" tag="ShowSpec"/>
     <tag group="ProductId" tag="HLCommunit"/>
     </thing>
-  <thing id="fPUBstCons" name="Boost Construct" description="Your astral constructs have more abilities.{br}{br}{b}Benefit:{/b} When you create an astral construct, you can give it one additional special ability from any menu that the construct currently has an ability from.{br}{br}{b}Special:{/b} This effect stacks with the summoner&apos;s call ability of the shaper." compset="Feat" summary="Your astral constructs have \nmore abilities." uniqueness="useronce">
+  <thing id="fPUBstCons" name="Boost Construct" description="Your astral constructs have more abilities.{br}{br}{b}Benefit:{/b} When you create an astral construct, you can give it one additional special ability from any menu that the construct currently has an ability from.{br}{br}{b}Special:{/b} This effect stacks with the summoner&apos;s call ability of the shaper.{br}{br}{b}Note:{/b} This feat is scripted to only work with Astral Constructs added through the Other tab." compset="Feat" summary="Your astral constructs has more abilities." uniqueness="useronce">
     <usesource source="pPsiUn"/>
-    <tag group="fCategory" tag="General"/>
+    <tag group="fCategory" tag="Psionic"/>
     <tag group="ProductId" tag="HLCommunit"/>
+    <eval phase="PreLevel" priority="10000"><![CDATA[
+      ~ If we're disabled, do nothing
+      doneif (tagis[Helper.FtDisable] <> 0)
+
+      ~ Find all Astral Construct minions and assign a helper
+      ~ tag to let the Astral Construct increase the allowed
+      ~ menu choices
+      foreach pick in hero from OnlyMinion where "gType.PUAstrCons"
+        perform eachpick.minion.assign[Psionics.AstConMenu]
+      nexteach]]></eval>
     </thing>
   <thing id="fPUBurPwr" name="Burrowing Power" description="Your powers sometimes bypass barriers.\n\n{b}Prerequisites:{/b} Spellcraft 8 ranks.\n\n{b}Benefit:{/b} To use this feat, you must expend your psionic focus. You can attempt to manifest your powers against targets that are sheltered behind a wall or force effect. Your power briefly skips through the Astral Plane to bypass the barrier.\n\nIf a power requires line of sight (which includes most powers that affect a target or targets instead of an area), you cannot manifest it as a burrowing power unless you can somehow see the target, such as with {i}clairvoyant sense{/i}. Using this feat increases the power point cost of the power by 4. The power&apos;s total cost cannot exceed your manifester level." compset="Feat" summary="Your powers sometimes bypass barriers." uniqueness="useronce">
     <usesource source="pPsiUn"/>
     <tag group="fCategory" tag="Metapsion"/>
-    <tag group="Helper" tag="ShowSpec" name="ShowSpec" abbrev="ShowSpec"/>
+    <tag group="Helper" tag="ShowSpec"/>
     <tag group="ProductId" tag="HLCommunit"/>
     <tag group="abAction" tag="PUExpFocus"/>
     <exprreq message="Spellcraft 8+ ranks required."><![CDATA[#skillranks[skSpellcr] >= 8]]></exprreq>
@@ -95,7 +105,7 @@
   <thing id="fPUChnPwr" name="Chain Power" description="You can manifest powers that arc to hit other targets in addition to the primary target.\n\n{b}Benefit{/b}: To use this feat, you must expend your psionic focus. You can chain any power that affects a single target and that deals either acid, cold, electricity, fire, or sonic damage. After the primary target is struck, the power can arc to a number of secondary targets equal to your manifester level (maximum twenty). The secondary arcs each strike one target and deal half as much damage as the primary one did (round down).\n\nEach target gets to make a saving throw, if one is allowed by the power. You choose secondary targets as you like, but they must all be within 30 feet of the primary target, and no target can be struck more than once. You can choose to affect fewer secondary targets than the maximum (to avoid allies in the area, for example).\n\nUsing this feat increases the power point cost of the power by 6. The power&apos;s total cost cannot exceed your manifester level.\n\nIf a power requires line of sight (which includes most powers that affect a target or targets instead of an area), you cannot manifest it as a burrowing power unless you can somehow see the target, such as with clairvoyant sense. Using this feat increases the power point cost of the power by 4. The power&apos;s total cost cannot exceed your manifester level." compset="Feat" summary="You can manifest powers that arc to hit other targets\nin addition to the primary target." uniqueness="useronce">
     <usesource source="pPsiUn"/>
     <tag group="fCategory" tag="Metapsion"/>
-    <tag group="Helper" tag="ShowSpec" name="ShowSpec" abbrev="ShowSpec"/>
+    <tag group="Helper" tag="ShowSpec"/>
     <tag group="ProductId" tag="HLCommunit"/>
     <tag group="abAction" tag="PUExpFocus"/>
     </thing>
@@ -109,7 +119,7 @@
   <thing id="fPUComMan" name="Combat Manifestation" description="You are adept at manifesting powers in combat.\n\n{b}Benefit{/b}: You get a +4 bonus on concentration checks made to manifest a power or use a psi-like ability when manifesting on the defensive or while grappled." compset="Feat" summary="+4 to Concentration checks to manifest power while on the defensive." uniqueness="useronce">
     <usesource source="pPsiUn"/>
     <tag group="fCategory" tag="Psionic"/>
-    <tag group="Helper" tag="ShowSpec" name="ShowSpec" abbrev="ShowSpec"/>
+    <tag group="Helper" tag="ShowSpec"/>
     <tag group="ProductId" tag="HLCommunit"/>
     <exprreq message="Psionic character required."><![CDATA[hero.tagis[Hero.Psionic] <> 0]]></exprreq>
     </thing>
@@ -125,7 +135,7 @@
   <thing id="fPUDeepImp" name="Deep Impact" description="You can strike your foe with a melee weapon as if making a touch attack.\n\n{b}Prerequisites{/b}: Str 13, Psionic Weapon, base attack bonus +6..\n\n{b}Benefit{/b}: To use this feat, you must expend your psionic focus as part of a melee attack. You can resolve that attack with a melee weapon as a touch attack. You must decide whether or not to use this feat prior to making an attack. If your attack misses, you still expend your psionic focus. Abilities that do not work on touch attacks similarly do not work with this feat." compset="Feat" summary="You can strike your foe with a melee weapon as if\nmaking a touch attack." uniqueness="useronce">
     <fieldval field="reqStr" value="13"/>
     <usesource source="pPsiUn"/>
-    <tag group="Helper" tag="ShowSpec" name="ShowSpec" abbrev="ShowSpec"/>
+    <tag group="Helper" tag="ShowSpec"/>
     <tag group="abAction" tag="PUExpFocus"/>
     <tag group="ProductId" tag="HLCommunit"/>
     <tag group="fCategory" tag="Psionic"/>
@@ -135,28 +145,28 @@
   <thing id="fPUDelPwr" name="Delay Power" description="You can manifest powers that go off up to 5 rounds later.\n\n{b}Benefit{/b}: To use this feat, you must expend your psionic focus. You can manifest a power as a delayed power. A delayed power doesn&apos;t activate immediately. When you manifest the power, you choose one of three trigger mechanisms: (1) The power activates when you take a standard action to activate it; (2) It activates when a creature enters the area that the power will affect (only powers that affect areas can use this trigger condition); or (3) It activates on your turn after 5 rounds pass. If you choose one of the first two triggers and the conditions are not met within 5 rounds, the power activates automatically on the fifth round.\n\nOnly area and personal powers can be delayed.\n\nAny decisions you would make about the delayed power, including attack rolls, designating targets, or determining or shaping an area, are decided when the power is manifested. Any effects resolved by those affected by the power, including saving throws, are decided when the delay period ends.\n\nA delayed power can be dispelled normally during the delay, and can be detected normally in the area or on the target by the use of powers that can detect psionic effects.\n\nUsing this feat increases the power point cost of the power by 2. The power&apos;s total cost cannot exceed your manifester level." compset="Feat" summary="You can manifest powers that go off up to 5 rounds\nlater." uniqueness="useronce">
     <usesource source="pPsiUn"/>
     <tag group="fCategory" tag="Metapsion"/>
-    <tag group="Helper" tag="ShowSpec" name="ShowSpec" abbrev="ShowSpec"/>
+    <tag group="Helper" tag="ShowSpec"/>
     <tag group="abAction" tag="PUExpFocus"/>
     <tag group="ProductId" tag="HLCommunit"/>
     </thing>
   <thing id="fPUEmpPwr" name="Empower Power" description="You can manifest powers to greater effect.\n\n{b}Benefit{/b}: To use this feat, you must expend your psionic focus. You can empower a power. All variable, numeric effects of an empowered power are increased by one-half. An empowered power deals half again as much damage as normal, cures half again as many hit points, affects half again as many targets, and so forth, as appropriate. Augmented powers can also be empowered (multiply 1-1/2 times the damage total of the augmented power). Saving throws and opposed checks (such as the one you make when you manifest dispel psionics) are not affected, nor are powers without random variables.\n\nUsing this feat increases the power point cost of the power by 2. The power&apos;s total cost cannot exceed your manifester level." compset="Feat" summary="Numeric effects of a power are increased 50%. +2 Power Points." uniqueness="useronce">
     <usesource source="pPsiUn"/>
     <tag group="fCategory" tag="Metapsion"/>
-    <tag group="Helper" tag="ShowSpec" name="ShowSpec" abbrev="ShowSpec"/>
+    <tag group="Helper" tag="ShowSpec"/>
     <tag group="abAction" tag="PUExpFocus"/>
     <tag group="ProductId" tag="HLCommunit"/>
     </thing>
   <thing id="fPUEndMind" name="Endowed Mind" description="You can make your powers more difficult to resist.\n\n{b}Benefit:{/b} As long as you maintain psionic focus, increase the save DC of any power you manifest by 1 for every 2 power points you spend augmenting the power, provided the augmentation does not already increase the power&apos;s save DC. You may even spend 2 power points to increase a power&apos;s save DC even if the power does not have any augment options.\n\n{b}Special:{/b} Unlike most metapsionic feats, you do not need to expend your psionic focus to use this feat" compset="Feat" summary="You can make your powers more difficult to resist." uniqueness="useronce">
     <usesource source="pPsiUn"/>
     <tag group="fCategory" tag="Metapsion"/>
-    <tag group="Helper" tag="ShowSpec" name="ShowSpec" abbrev="ShowSpec"/>
+    <tag group="Helper" tag="ShowSpec"/>
     <tag group="abAction" tag="PUManFocus"/>
     <tag group="ProductId" tag="HLCommunit"/>
     </thing>
   <thing id="fPUEnlPwr" name="Enlarge Power" description="You can manifest powers farther than normal.\n\n{b}Benefit{/b}: To use this feat, you must expend your psionic focus. You can alter a power with a range of close, medium, or long to increase its range by 100%. An enlarged power with a range of close has a range of 50 feet + 5 feet per level, a medium-range power has a range of 200 feet + 20 feet per level, and a long-range power has a range of 800 feet + 80 feet per level. \n\nPowers whose ranges are not defined by distance, as well as powers whose ranges are not close, medium, or long, are not affected.\n\nUsing this feat does not increase the power point cost of the power." compset="Feat" summary="You can manifest powers farther than normal." uniqueness="useronce">
     <usesource source="pPsiUn"/>
     <tag group="fCategory" tag="Metapsion"/>
-    <tag group="Helper" tag="ShowSpec" name="ShowSpec" abbrev="ShowSpec"/>
+    <tag group="Helper" tag="ShowSpec"/>
     <tag group="abAction" tag="PUExpFocus"/>
     <tag group="ProductId" tag="HLCommunit"/>
     </thing>
@@ -357,7 +367,7 @@
     <fieldval field="usrCandid1" value="component.Simple &amp; Psicrystal.Personalty"/>
     <usesource source="pPsiUn"/>
     <tag group="fCategory" tag="Psionic" name="Psionic" abbrev="Psionic"/>
-    <tag group="Helper" tag="ShowSpec" name="ShowSpec" abbrev="ShowSpec"/>
+    <tag group="Helper" tag="ShowSpec"/>
     <tag group="ChooseSrc1" tag="Hero"/>
     <tag group="ProductId" tag="HLCommunit"/>
     <eval phase="First" priority="400" index="3">~ Give a bonus level to the psicyrstal
@@ -388,7 +398,7 @@
     <usesource source="pPsiUn"/>
     <tag group="ProductId" tag="HLCommunit"/>
     <tag group="abAction" tag="PUExpFocus"/>
-    <tag group="Helper" tag="ShowSpec" name="ShowSpec" abbrev="ShowSpec"/>
+    <tag group="Helper" tag="ShowSpec"/>
     <tag group="abAction" tag="PUManFocus"/>
     <tag group="fCategory" tag="Psionic"/>
     <eval phase="PostAttr" priority="10000"><![CDATA[      ~ If we're disabled, do nothing
@@ -588,7 +598,7 @@
     <tag group="fCategory" tag="Psionic"/>
     <tag group="abAction" tag="PUExpFocus"/>
     <tag group="ProductId" tag="HLCommunit"/>
-    <tag group="Helper" tag="ShowSpec" name="ShowSpec" abbrev="ShowSpec"/>
+    <tag group="Helper" tag="ShowSpec"/>
     <exprreq message="Speed of Thought required."><![CDATA[#hasfeat[fPUSpdThgt] <> 0]]></exprreq>
     </thing>
   <thing id="fPUPsiDodg" name="Psionic Dodge" description="You are proficient at dodging blows.\n\n{b}Prerequisites{/b}: Dex 13, Dodge.\n\n{b}Benefit{/b}: You must be psionically focused to use this feat. You receive a +1 dodge bonus to your Armor Class. This bonus stacks with the bonus from the Dodge feat. You may expend your psionic focus as an immediate action to increase this bonus to a +4 dodge bonus to your Armor Class for a single attack made against you." compset="Feat" summary="+1 AC when psi-focused, expend focus for +4 vs. one attack" uniqueness="useronce">
@@ -598,7 +608,7 @@
     <fieldval field="reqDex" value="13"/>
     <usesource source="pPsiUn"/>
     <tag group="abAction" tag="PUManFocus"/>
-    <tag group="Helper" tag="ShowSpec" name="ShowSpec" abbrev="ShowSpec"/>
+    <tag group="Helper" tag="ShowSpec"/>
     <tag group="User" tag="Activation"/>
     <tag group="fCategory" tag="Psionic" name="Psionic" abbrev="Psionic"/>
     <tag group="ProductId" tag="HLCommunit"/>
@@ -642,7 +652,7 @@
     <usesource source="pPsiUn"/>
     <tag group="fCategory" tag="Psionic" name="Psionic" abbrev="Psionic"/>
     <tag group="User" tag="Activation"/>
-    <tag group="Helper" tag="ShowSpec" name="ShowSpec" abbrev="ShowSpec"/>
+    <tag group="Helper" tag="ShowSpec"/>
     <tag group="abAction" tag="PUManFocus"/>
     <tag group="abAction" tag="PUExpFocus"/>
     <tag group="ProductId" tag="HLCommunit"/>
@@ -713,7 +723,7 @@
     <tag group="ProductId" tag="HLCommunit"/>
     <tag group="User" tag="Activation"/>
     <tag group="fCategory" tag="Psionic"/>
-    <tag group="Helper" tag="ShowSpec" name="ShowSpec" abbrev="ShowSpec"/>
+    <tag group="Helper" tag="ShowSpec"/>
     <tag group="abAction" tag="PUExpFocus"/>
     <tag group="abAction" tag="PUManFocus"/>
     <eval phase="Final" priority="50000"><![CDATA[
@@ -731,7 +741,7 @@
     </thing>
   <thing id="fPUQuiPwr" name="Quicken Power" description="You can manifest a power with a moment&apos;s thought.\n\n{b}Benefit{/b}: To use this feat, you must expend your psionic focus. You can quicken a power. You can perform another action, even manifest another power, in the same round that you manifest a quickened power. You can manifest only one quickened power per round. A power whose manifesting time is longer than 1 round cannot be quickened.\n  Using this feat increases the power point cost of the power by 6. The power&apos;s total cost cannot exceed your manifester level.\n  Manifesting a quickened power does not provoke attacks of opportunity." compset="Feat" summary="You can manifest a power with a moment&apos;s thought." uniqueness="useronce">
     <usesource source="pPsiUn"/>
-    <tag group="Helper" tag="ShowSpec" name="ShowSpec" abbrev="ShowSpec"/>
+    <tag group="Helper" tag="ShowSpec"/>
     <tag group="fCategory" tag="Metapsion" name="Metapsionic" abbrev="Metapsionic"/>
     <tag group="abAction" tag="PUExpFocus"/>
     <tag group="ProductId" tag="HLCommunit"/>
@@ -741,14 +751,14 @@
     <usesource source="pPsiUn"/>
     <tag group="fCategory" tag="General" name="General" abbrev="General"/>
     <tag group="ProductId" tag="HLCommunit"/>
-    <tag group="Helper" tag="ShowSpec" name="ShowSpec" abbrev="ShowSpec"/>
+    <tag group="Helper" tag="ShowSpec"/>
     </thing>
   <thing id="fPUReckOff" name="Reckless Offense" description="You can shift your focus from defense to offense.\n\n{b}Prerequisites{/b}: Base attack bonus +1.\n\n{b}Benefit{/b}: When you use the attack action or full attack action in melee, you can take a penalty of -4 to your Armor Class and add a +2 bonus on your melee attack roll. The bonus on attack rolls and penalty to Armor Class last until the beginning of your next turn." compset="Feat" summary="You can shift your focus from defense to offense." uniqueness="useronce">
     <fieldval field="actName" value="Reckless Offense"/>
     <usesource source="pPsiUn"/>
     <tag group="fCategory" tag="General" name="General" abbrev="General"/>
     <tag group="User" tag="Activation"/>
-    <tag group="Helper" tag="ShowSpec" name="ShowSpec" abbrev="ShowSpec"/>
+    <tag group="Helper" tag="ShowSpec"/>
     <tag group="ProductId" tag="HLCommunit"/>
     <eval phase="PostAttr" priority="14001"><![CDATA[      ~ If we're disabled, do nothing
       doneif (tagis[Helper.FtDisable] <> 0)
@@ -766,7 +776,7 @@
     </thing>
   <thing id="fPUReturnS" name="Return Shot" description="You can return incoming arrows, as well as crossbow bolts, spears, and other projectile or thrown weapons.\n\n{b}Prerequisites{/b}: Point Blank Shot, Psionic Shot, Fell Shot, base attack bonus +6.\n\n{b}Benefit{/b}: To use this feat, you must expend your psionic focus and have at least one hand free. Once per round when you would normally be hit by a projectile or a thrown weapon no more than one size category larger than your size, you can deflect the attack so that you take no damage from it. The attack is deflected back at your attacker, using the attack bonus of the original attack on you. You must be aware of the attack and not flat-footed. Attempting to return a shot is a free action.\n\n{b}Special{/b}: If you also have the Deflect Arrows feat, the deflected attack is made with the original attack bonus plus your Dexterity bonus." compset="Feat" summary="You can return incoming arrows, as well as crossbow bolts, spears, and other projectile or thrown weapons." uniqueness="useronce">
     <usesource source="pPsiUn"/>
-    <tag group="Helper" tag="ShowSpec" name="ShowSpec" abbrev="ShowSpec"/>
+    <tag group="Helper" tag="ShowSpec"/>
     <tag group="fCategory" tag="Psionic" name="Psionic" abbrev="Psionic"/>
     <tag group="abAction" tag="PUExpFocus"/>
     <tag group="ProductId" tag="HLCommunit"/>
@@ -788,7 +798,7 @@
     <usesource source="pPsiUn"/>
     <tag group="fCategory" tag="General" name="General" abbrev="General"/>
     <tag group="ProductId" tag="HLCommunit"/>
-    <tag group="Helper" tag="ShowSpec" name="ShowSpec" abbrev="ShowSpec"/>
+    <tag group="Helper" tag="ShowSpec"/>
     <exprreq message="Dodge required." iserror="no"><![CDATA[#hasfeat[fDodge] <> 0]]></exprreq>
     </thing>
   <thing id="fPUSpdThgt" name="Speed of Thought" description="The energy of your mind energizes the alacrity of your body.{br}{br}{b}Prerequisite:{/b} Wis 13.{br}{br}{b}Benefit:{/b} As long as you are psionically focused and not wearing heavy armor, you gain an insight bonus to your speed of 10 feet. You may expend your psionic focus to increase the insight bonus to your speed to 30 feet for your turn." compset="Feat" summary="When focused speed +10ft or +30ft when you expend focus." uniqueness="useronce">
@@ -797,7 +807,7 @@
     <usesource source="pPsiUn"/>
     <tag group="fCategory" tag="Psionic"/>
     <tag group="User" tag="Activation"/>
-    <tag group="Helper" tag="ShowSpec" name="ShowSpec" abbrev="ShowSpec"/>
+    <tag group="Helper" tag="ShowSpec"/>
     <tag group="abAction" tag="PUManFocus"/>
     <tag group="abAction" tag="PUExpFocus"/>
     <tag group="ProductId" tag="HLCommunit"/>
@@ -835,7 +845,7 @@
     </thing>
   <thing id="fPUTalent" name="Talented" description="You can overchannel powers with less cost to yourself.\n\n{b}Prerequisites:{/b} Overchannel. \n\n{b}Benefit:{/b} To use this feat, you must expend your psionic focus. When manifesting a power of 3rd level or lower, you do not take damage from overchanneling." compset="Feat" summary="You can overchannel powers with less cost to yourself." uniqueness="useronce">
     <usesource source="pPsiUn"/>
-    <tag group="Helper" tag="ShowSpec" name="ShowSpec" abbrev="ShowSpec"/>
+    <tag group="Helper" tag="ShowSpec"/>
     <tag group="fCategory" tag="Psionic"/>
     <tag group="abAction" tag="PUExpFocus"/>
     <tag group="ProductId" tag="HLCommunit"/>
@@ -854,13 +864,13 @@
     <tag group="fCategory" tag="Psionic" name="Psionic" abbrev="Psionic"/>
     <tag group="abAction" tag="PUExpFocus"/>
     <tag group="ProductId" tag="HLCommunit"/>
-    <tag group="Helper" tag="ShowSpec" name="ShowSpec" abbrev="ShowSpec"/>
+    <tag group="Helper" tag="ShowSpec"/>
     <exprreq message="Base attack bonus +6 required." iserror="no"><![CDATA[child[Attack].field[tAtkBase].value >= 6]]></exprreq>
     <exprreq message="Psionic Fist required." iserror="no"><![CDATA[#hasfeat[fPUPsiFist] <> 0]]></exprreq>
     </thing>
   <thing id="fPUUncPwr" name="Unconditional Power" description="Disabling conditions do not hold you back.\n\n{b}Benefit{/b}: To use this feat, you must expend your psionic focus. Your mental strength is enough to overcome some otherwise disabling conditions. You can manifest an unconditional power when you are dazed, {i}confused{/i}, nauseated, shaken, or stunned.\n  Only personal powers and powers that affect your person can be manifested as unconditional powers.\n  Using this feat increases the power point cost of the power by 8. The power&apos;s total cost cannot exceed your manifester level." compset="Feat" summary="Disabling conditions do not hold you back." uniqueness="useronce">
     <usesource source="pPsiUn"/>
-    <tag group="Helper" tag="ShowSpec" name="ShowSpec" abbrev="ShowSpec"/>
+    <tag group="Helper" tag="ShowSpec"/>
     <tag group="fCategory" tag="Metapsion" name="Metapsionic" abbrev="Metapsionic"/>
     <tag group="abAction" tag="PUExpFocus"/>
     <tag group="ProductId" tag="HLCommunit"/>
@@ -871,11 +881,11 @@
     <tag group="fCategory" tag="Psionic" name="Psionic" abbrev="Psionic"/>
     <tag group="abAction" tag="PUManFocus"/>
     <tag group="ProductId" tag="HLCommunit"/>
-    <tag group="Helper" tag="ShowSpec" name="ShowSpec" abbrev="ShowSpec"/>
+    <tag group="Helper" tag="ShowSpec"/>
     </thing>
   <thing id="fPUWidPwr" name="Widen Power" description="You can increase the area of your powers.\n\n{b}Benefit{/b}: To use this feat, you must expend your psionic focus. You can alter a burst, emanation, line, or spread-shaped power to increase its area. (Powers that do not have an area of one of these four sorts are not affected by this feat.) Any numeric measurements of the power&apos;s area increase by 100%.\n  Using this feat increases the power point cost of the power by 4. The power&apos;s total cost cannot exceed your manifester level." compset="Feat" summary="You can increase the area of your powers." uniqueness="useronce">
     <usesource source="pPsiUn"/>
-    <tag group="Helper" tag="ShowSpec" name="ShowSpec" abbrev="ShowSpec"/>
+    <tag group="Helper" tag="ShowSpec"/>
     <tag group="fCategory" tag="Metapsion" name="Metapsionic" abbrev="Metapsionic"/>
     <tag group="abAction" tag="PUExpFocus"/>
     <tag group="ProductId" tag="HLCommunit"/>
@@ -906,7 +916,7 @@
     </thing>
   <thing id="fPUWndAtt" name="Wounding Attack" description="Your vicious attacks wound your foe.\n\n{b}Prerequisite:{/b} Base attack bonus +8.\n\n{b}Benefit:{/b} To use this feat, you must expend your psionic focus. You can make an attack with such vicious force that you wound your opponent. A wound deals 1 point of Constitution damage to your foe in addition to the usual damage dealt.\n  You must decide whether or not to use this feat prior to making an attack. If your attack misses, you still expend your psionic focus." compset="Feat" uniqueness="useronce">
     <usesource source="pPsiUn" parent="UserParent" name="Psionics Unleashed: Feats and Skills"/>
-    <tag group="Helper" tag="ShowSpec" name="ShowSpec" abbrev="ShowSpec"/>
+    <tag group="Helper" tag="ShowSpec"/>
     <tag group="fCategory" tag="Psionic"/>
     <tag group="abAction" tag="PUExpFocus"/>
     <tag group="ProductId" tag="HLCommunit"/>
@@ -951,7 +961,7 @@
     </thing>
   <thing id="fPUSurAur" name="Surging Aura" description="Your wild surge enhances the aim of nearby allies.\n\n{b}Prerequisites:{/b} Wild Surge +1. \n\n{b}Benefit:{/b} You gain a 10&apos; surging aura. When you use your wild surge class feature, you can designate one ally for every +1 of your wild surge within the surging aura to gain an insight bonus to attack rolls equal to your wild surge until the end of their next turn." compset="Feat" summary="Your wild surge enhances the aim of nearby allies." uniqueness="useronce">
     <usesource source="pPsiUn"/>
-    <tag group="Helper" tag="ShowSpec" name="ShowSpec" abbrev="ShowSpec"/>
+    <tag group="Helper" tag="ShowSpec"/>
     <tag group="fCategory" tag="Psionic"/>
     <tag group="ProductId" tag="HLCommunit"/>
     <eval phase="Final" priority="30000"><![CDATA[
@@ -966,7 +976,7 @@
     </thing>
   <thing id="fPUSwftSha" name="Swift Shapeshifter" description="You are naturally confident with different shapes and forms, and years of training have allowed your body to more easily flow into new shapes.\n\n{b}Prerequisites:{/b} Ability to manifest {i}metamorphosis{/i}.\n\n{b}Benefit:{/b} When you manifest {i}minor metamorphosis{/i}, {i}major metamorphosis{/i} or {i}metamorphosis{/i} the manifestation time is a move action instead of a standard action." compset="Feat" uniqueness="useronce">
     <usesource source="pPsiUn"/>
-    <tag group="Helper" tag="ShowSpec" name="ShowSpec" abbrev="ShowSpec"/>
+    <tag group="Helper" tag="ShowSpec"/>
     <tag group="fCategory" tag="Psionic"/>
     <tag group="ProductId" tag="HLCommunit"/>
     <prereq message="Ability to manifest {i}metamorphosis{/i}">
@@ -1144,8 +1154,9 @@ validif (hero.tagcount[Hero.Manifester] >= 10)]]></validate>
     <exprreq message="Brawler path class feature required."><![CDATA[#hasability[cWPaBraPri] <> 0]]></exprreq>
     <exprreq message="Improved Grapple feat required"><![CDATA[#hasfeat[fImpGrapp] <> 0]]></exprreq>
     <prereq message="Manifester level 10 required">
-      <validate><![CDATA[~check for Manifester level 10
-validif (hero.tagcount[Hero.Manifester] >= 10)]]></validate>
+      <validate><![CDATA[
+        ~check for Manifester level 10
+        validif (hero.tagcount[Hero.Manifester] >= 10)]]></validate>
       </prereq>
     </thing>
   <thing id="fPUAdvCons" name="Advanced Constructs" description="You are especially skilled at creating astral constructs.\n\n{b}Prerequisite:{/b} Able to manifest {i}astral construct{/i}.\n\n{b}Benefit:{/b} You gain additional menu options for astral constructs, as detailed below.\n\n{b}{i}Menu A{/b}{/i}\n{b}Armor Spikes (Ex):{/b} The construct’s body is covered in spikes, allowing the construct to deal an extra 1d6 points of piercing damage with a successful trample, constrict, bull rush, or grapple attack. The construct also can make a regular melee attack with the spikes, dealing 1d6 points of damage.\n{b}Dodge (Ex):{/b} The astral construct gains the Dodge feat even if it does not meet the prerequisites.\n{b}Psionic Attacks (Su):{/b} The astral construct’s attacks are treated as psionic for the purposes of overcoming damage reduction.\n{b}Might (Ex):{/b} The astral construct’s melee attacks deal an additional +1 point of damage.\n{b}Talons (Ex):{/b} The astral construct replaces its slam attacks with claw attacks that deal either slashing or piercing damage, chosen at time of manifestation.\n{b}Utility (Ex):{/b} Your construct can perform tasks for you. This can include such tasks as cleaning, cooking, or setting up camp, or any other activity that requires a DC 10 or lower skill check. An astral construct with this option does not need to stay close to the manifester and will continue following any given order until given other instructions. You can select this menu option multiple\ntimes. Each time, the DC of skill checks the construct can attempt increases by 2. An astral construct with this option that is not used in combat has a duration of 1 hour / level. If it later enters combat, its duration resets to 1 round / level, but suffers a -2 penalty to its attack rolls.\n\n{b}{i}Menu B{/b}{/i}\n{b}Great Cleave (Ex):{/b} The astral construct gains the Great Cleave feat even if it does not meet the prerequisites.\n{b}Improved Might (Ex):{/b} The astral construct’s melee attacks deal an additional +3 points of damage. This does not stack with the Might menu option.\n{b}Reach (Ex):{/b} The astral construct’s reach increases by 5 feet.\n{b}Stunning Fist (Ex):{/b} The astral construct gains the Stunning Fist feat even if it does not meet the prerequisites. The construct can use Stunning Fist with its slam attack.\n\n{b}{i}Menu C{/b}{/i}\n{b}Greater Might (Ex):{/b} The astral construct’s melee attacks deal an additional +5 points of damage. This does not stack with the Improved Might or Might menu option.\n{b}Tail Slap (Ex):{/b} The astral construct gains a tail, giving it a tail slap secondary attack. A tail slap deals 2d8 points of damage." compset="Feat" uniqueness="useronce">
@@ -1154,11 +1165,12 @@ validif (hero.tagcount[Hero.Manifester] >= 10)]]></validate>
     <tag group="fCategory" tag="Psionic"/>
     <tag group="ProductId" tag="HLCommunit"/>
     <prereq message="Able to manifest {i}astral construct{/i}">
-      <validate><![CDATA[    var PowerID as String
-    var HavePower as number
-    PowerID = "puAstCons1"
-    Call HavePower
-    @valid = HavePower]]></validate>
+      <validate><![CDATA[
+        var PowerID as String
+        var HavePower as number
+        PowerID = "puAstCons1"
+        Call HavePower
+        @valid = HavePower]]></validate>
       </prereq>
     </thing>
   <thing id="fPUAdDerPa" name="Advanced Dervish Path" description="You seem to float between enemies, a blur of destruction.{br}{br}{b}Prerequisites:{/b} Dex 15, Double Slice, Two-Weapon Fighting, Dervish path class feature, manifester level 10th, base attack bonus +6 \n\n{b}Benefit:{/b} When using the Dervish trance, the competence bonus applies to your damage as well as your attack rolls. In addition, you can use the Dervish maneuver even if you moved before your attack and you have no limit of how many 5-foot steps you can take while using the Dervish maneuver, as long as you make at least one attack before each 5-foot step. The maximum distance you can move in this round is that of a double move." compset="Feat" uniqueness="useronce">
@@ -2275,7 +2287,7 @@ validif (hero.tagcount[Hero.Manifester] >= 3)]]></validate>
     <usesource source="pPsiUn"/>
     <tag group="Helper" tag="ShowSpec"/>
     <tag group="trCategory" tag="Psionic" name="Psionic"/>
-    <eval phase="PostLevel" priority="10000"><![CDATA[
+    <eval phase="PostLevel" priority="10000">
       var v_focus as number
       call PUPsiFocus
       ~ If we are not psionic focus get out now!
@@ -2284,7 +2296,7 @@ validif (hero.tagcount[Hero.Manifester] >= 3)]]></validate>
       field[abValue].value += 1
 
       #applybonus[BonTrait,hero.child[Initiative],field[abValue].value]
-      #applybonus[BonTrait,hero.childfound[skSenseMot],field[abValue].value]]]></eval>
+      #applybonus[BonTrait,hero.childfound[skSenseMot],field[abValue].value]</eval>
     </thing>
   <thing id="trPUPsigif" name="Psigifted" description="You have an affinity for one particular power chosen from ones that you know, and your effective manifester level for that psionic power increases by 1. Once this power is selected it cannot be changed." compset="Trait">
     <fieldval field="usrCandid1" value="component.BasePower"/>

--- a/COM_3PPPack_UltimatePsionics - Helper Things.user
+++ b/COM_3PPPack_UltimatePsionics - Helper Things.user
@@ -30,6 +30,12 @@
     <tag group="abCategory" tag="PUPsyPath"   name="Psychic Warrior Path" abbrev="Path"/>
     <tag group="abCategory" tag="PUPsyWarMa"  name="Psy Warrior Maneuver" abbrev="Maneuver"/>
     <tag group="abCategory" tag="PUPsyWarTr"  name="Psy Warrior Trance"   abbrev="Trance"/>
+    <tag group="AllowRCust" tag="PUMenuA"     name="Menu A" abbrev="A"/>
+    <tag group="AllowRCust" tag="PUMenuB"     name="Menu B" abbrev="B"/>
+    <tag group="AllowRCust" tag="PUMenuC"     name="Menu C" abbrev="C"/>
+    <tag group="gType"      tag="PUPsionics"  name="Psionics"/>
+    <tag group="gType"      tag="PUAstrCons"  name="Astral Construct"/>
+    <tag group="gType"      tag="PUPsicrsta"  name="Psicrystals"/>
 
     <bootstrap thing="PUPathSk"></bootstrap>
     <bootstrap thing="PUClassFnd"></bootstrap>
@@ -343,8 +349,10 @@
     <link linkage="varies" thing="cHelpBSn"/>
     </thing>
 
-  <thing id="minHdPUPsc" name="Psicrystals" compset="Minion" isshowonly="yes">
-    <tag group="gType" tag="PUPsicrsta" name="Psicrystals"/>
+  <thing id="minHdPUPsc" name="Psionics" compset="Minion" isshowonly="yes">
+    <tag group="gType" tag="PUPsionics"/>
+    <tag group="gType" tag="PUPsicrsta"/>
+    <tag group="gType" tag="PUAstrCons"/>
     </thing>
 
   </document>

--- a/COM_3PPPack_UltimatePsionics - Psicrystal.user
+++ b/COM_3PPPack_UltimatePsionics - Psicrystal.user
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <document signature="Hero Lab Data">
   <loadonce key="COM_3PPPack_UltimatePsionics - Psicrystal"/>
-  <fileinfo>
-    <info_history>April 2, 2014 - Tim Shadow
--Fixed Psicrystal to no longer ask for a class level.</info_history>
-    </fileinfo>
   <thing id="abPUAlertn" name="Alertness" description="The presence of a psicrystal sharpens its master&apos;s senses. While a psicrystal is within arm&apos;s reach (adjacent to or in the same square as its owner), its owner gains the Alertness feat." compset="Ability" summary="While a psicrystal is within arm&apos;s reach, its owner gains the Alertness feat." uniqueness="useronce">
     <fieldval field="actName" value="Within Arms Reach"/>
     <fieldval field="actName2" value="Within 1 Mile"/>
@@ -28,10 +24,11 @@
       #skillbonus[skSenseMot] += field[abValue2].value]]>
       <after name="fAlertness assigns Hero.fAlertness"/>
       </eval>
-    <eval phase="PostLevel" priority="20000" index="3">~ Setup for all the psicrystal personality bonuses
-      Call PsicryPers</eval>
+    <eval phase="PostLevel" priority="20000" index="3"><![CDATA[
+      ~ Setup for all the psicrystal personality bonuses &
+      Call PsicryPers]]></eval>
     <eval phase="First" priority="10000"><![CDATA[
-      ~ If we're within arm's reach, make sure our 'within 1 mile' 
+      ~ If we're within arm's reach, make sure our 'within 1 mile'
       ~ field is selected and locked
       if (field[abilActive].value <> 0) then
         trustme
@@ -46,7 +43,7 @@
         perform hero.assign[Psicrystal.MasterMile]
       endif
 
-      ~we had used the livename as a storage for the information about 
+      ~we had used the livename as a storage for the information about
       ~what familiar bonus we got use that to generate a summary,
       ~ then restore the livename to a name
       if (field[livename].isempty = 0) then
@@ -115,87 +112,90 @@
     <bootstrap thing="raPUPerson"></bootstrap>
     <bootstrap thing="raPUShaPwr"></bootstrap>
     <bootstrap thing="raPUSighte"></bootstrap>
-    <eval phase="Final" priority="50000" index="4"><![CDATA[~ Set the psicrystal's saves to be the equal to the masters base
-~ save plus attribute.
-hero.child[svFort].field[svTotal].value = master.hero.child[svFort].field[svBase].value + master.hero.child[svFort].field[svAttr].value
-hero.child[svRef].field[svTotal].value = master.hero.child[svRef].field[svBase].value + master.hero.child[svRef].field[svAttr].value
-hero.child[svWill].field[svTotal].value = master.hero.child[svWill].field[svBase].value + master.hero.child[svWill].field[svAttr].value]]></eval>
+    <eval phase="Final" priority="50000" index="4"><![CDATA[
+      ~ Set the psicrystal's saves to be the equal to the masters base
+      ~ save plus attribute.
+      hero.child[svFort].field[svTotal].value = master.hero.child[svFort].field[svBase].value + master.hero.child[svFort].field[svAttr].value
+      hero.child[svRef].field[svTotal].value = master.hero.child[svRef].field[svBase].value + master.hero.child[svRef].field[svAttr].value
+      hero.child[svWill].field[svTotal].value = master.hero.child[svWill].field[svBase].value + master.hero.child[svWill].field[svAttr].value]]></eval>
     <eval phase="First" priority="490"><![CDATA[
-~ Set skill bonsues
-#skillbonus[skPercep] += 6
+      ~ Set skill bonsues
+      #skillbonus[skPercep] += 6
 
-~ Pull Masters alignment and set to ourself
-perform master.hero.findchild[Alignment].pulltags[Alignment.?]
-~perform master.hero.pulltags[Alignment.?]
-perform forward[Alignment.?]
+      ~ Pull Masters alignment and set to ourself
+      perform master.hero.findchild[Alignment].pulltags[Alignment.?]
+      ~perform master.hero.pulltags[Alignment.?]
+      perform forward[Alignment.?]
 
-~ Hide the Unarmed Attack weapon
-perform hero.child[wUnarmed].assign[Hide.Weapon]
-~ Set level to the number of Psionic Classes the master has
-field[anCompLev].value += master.hero.tagcount[Psionics.Class]
-~ Give any bonus levels like from "improved psicyrstal" feat
-field[anCompLev].value += master.hero.tagcount[Psicrystal.BonusLvl]
+      ~ Hide the Unarmed Attack weapon
+      perform hero.child[wUnarmed].assign[Hide.Weapon]
+      ~ Set level to the number of Psionic Classes the master has
+      field[anCompLev].value += master.hero.tagcount[Psionics.Class]
+      ~ Give any bonus levels like from "improved psicyrstal" feat
+      field[anCompLev].value += master.hero.tagcount[Psicrystal.BonusLvl]
 
-~ Set the correct Intelligence and Natural Armor bonus
-If (field[anCompLev].value >= 19) Then
-  hero.child[aINT].field[aStartMod].value += 9
-  hero.child[ArmorClass].field[tACNatural].value += 9
-ElseIf (field[anCompLev].value >= 17) Then
-  hero.child[aINT].field[aStartMod].value += 8
-  hero.child[ArmorClass].field[tACNatural].value += 8
-ElseIf (field[anCompLev].value >= 15) Then
-  hero.child[aINT].field[aStartMod].value += 7
-  hero.child[ArmorClass].field[tACNatural].value += 7
-ElseIf (field[anCompLev].value >= 13) Then
-  hero.child[aINT].field[aStartMod].value += 6
-  hero.child[ArmorClass].field[tACNatural].value += 6
-ElseIf (field[anCompLev].value >= 11) Then
-  hero.child[aINT].field[aStartMod].value += 5
-  hero.child[ArmorClass].field[tACNatural].value += 5
-ElseIf (field[anCompLev].value >= 9) Then
-  hero.child[aINT].field[aStartMod].value += 4
-  hero.child[ArmorClass].field[tACNatural].value += 4
-ElseIf (field[anCompLev].value >= 7) Then
-  hero.child[aINT].field[aStartMod].value += 3
-  hero.child[ArmorClass].field[tACNatural].value += 3
-ElseIf (field[anCompLev].value >= 5) Then
-  hero.child[aINT].field[aStartMod].value += 2
-  hero.child[ArmorClass].field[tACNatural].value += 2
-ElseIf (field[anCompLev].value >= 3) Then
-  hero.child[aINT].field[aStartMod].value += 1
-  hero.child[ArmorClass].field[tACNatural].value += 1
-Endif]]></eval>
+      ~ Set the correct Intelligence and Natural Armor bonus
+      If (field[anCompLev].value >= 19) Then
+        hero.child[aINT].field[aStartMod].value += 9
+        hero.child[ArmorClass].field[tACNatural].value += 9
+      ElseIf (field[anCompLev].value >= 17) Then
+        hero.child[aINT].field[aStartMod].value += 8
+        hero.child[ArmorClass].field[tACNatural].value += 8
+      ElseIf (field[anCompLev].value >= 15) Then
+        hero.child[aINT].field[aStartMod].value += 7
+        hero.child[ArmorClass].field[tACNatural].value += 7
+      ElseIf (field[anCompLev].value >= 13) Then
+        hero.child[aINT].field[aStartMod].value += 6
+        hero.child[ArmorClass].field[tACNatural].value += 6
+      ElseIf (field[anCompLev].value >= 11) Then
+        hero.child[aINT].field[aStartMod].value += 5
+        hero.child[ArmorClass].field[tACNatural].value += 5
+      ElseIf (field[anCompLev].value >= 9) Then
+        hero.child[aINT].field[aStartMod].value += 4
+        hero.child[ArmorClass].field[tACNatural].value += 4
+      ElseIf (field[anCompLev].value >= 7) Then
+        hero.child[aINT].field[aStartMod].value += 3
+        hero.child[ArmorClass].field[tACNatural].value += 3
+      ElseIf (field[anCompLev].value >= 5) Then
+        hero.child[aINT].field[aStartMod].value += 2
+        hero.child[ArmorClass].field[tACNatural].value += 2
+      ElseIf (field[anCompLev].value >= 3) Then
+        hero.child[aINT].field[aStartMod].value += 1
+        hero.child[ArmorClass].field[tACNatural].value += 1
+      Endif]]></eval>
     <eval phase="PreLevel" priority="4000" index="2"><![CDATA[
-var sTag as string
+      var sTag as string
 
-~ Loop through all the masters skills
-foreach pick in master from BaseSkill
-  ~ If we have user entered ranks then attempt to give them
-  ~ to the psicrystal.
-  If (eachpick.field[skUser].value <> 0) Then
-    ~ Save the ThingID tag
-    sTag = eachpick.tagids[thingid.?]
-    ~ Find the same skill on the minion
-    perform hero.findchild[BaseSkill,sTag].setfocus
-    ~ If we got a lock then set minion skill
-    If (state.isfocus <> 0) Then
-      ~ Add the master ranks to the minon's skill bonus.
-      focus.field[Bonus].value += eachpick.field[skUser].value
-      ~ Remove the Not Usable tag so that the bonus always displays
-      perform focus.delete[Helper.NotUsable]
-      perform focus.delete[Helper.TrainOnly]
-      ~ Clear the focus so we can focus again on the next 
-      perform state.clearfocus
-    Endif
-  Endif  
-nexteach]]></eval>
-    <eval phase="Final" priority="5000" index="3">var hitpoints as number
-~ Total up the Masters Hit Points
-hitpoints = master.hero.child[Totals].field[tHP].value + master.hero.child[Totals].field[tBonusHP].value
-~ We have hit points equal to half our master
-herofield[tHP].value = round(hitpoints/2,0,-1)</eval>
-    <eval phase="PostAttr" priority="50000" index="5">~ Remove skill points
-#resmax[resSkill] = 0</eval>
+      ~ Loop through all the masters skills
+      foreach pick in master from BaseSkill
+        ~ If we have user entered ranks then attempt to give them
+        ~ to the psicrystal.
+        If (eachpick.field[skUser].value <> 0) Then
+          ~ Save the ThingID tag
+          sTag = eachpick.tagids[thingid.?]
+          ~ Find the same skill on the minion
+          perform hero.findchild[BaseSkill,sTag].setfocus
+          ~ If we got a lock then set minion skill
+          If (state.isfocus <> 0) Then
+            ~ Add the master ranks to the minon's skill bonus.
+            focus.field[Bonus].value += eachpick.field[skUser].value
+            ~ Remove the Not Usable tag so that the bonus always displays
+            perform focus.delete[Helper.NotUsable]
+            perform focus.delete[Helper.TrainOnly]
+            ~ Clear the focus so we can focus again on the next
+            perform state.clearfocus
+          Endif
+        Endif
+      nexteach]]></eval>
+    <eval phase="Final" priority="5000" index="3"><![CDATA[
+      var hitpoints as number
+      ~ Total up the Masters Hit Points &
+      hitpoints = master.hero.child[Totals].field[tHP].value + master.hero.child[Totals].field[tBonusHP].value
+      ~ We have hit points equal to half our master
+      herofield[tHP].value = round(hitpoints/2,0,-1)]]></eval>
+    <eval phase="PostAttr" priority="50000" index="5"><![CDATA[
+      ~ Remove skill points &
+      #resmax[resSkill] = 0]]></eval>
     <exprreq message="This race is only valid to be taken when added on the &quot;Other&quot; tab."><![CDATA[hero.tagis[system_tag.minion] <> 0]]></exprreq>
     </thing>
   <thing id="raPUPerson" name="Personality" description="Each psicrystal has a distinct personality, chosen by its owner at the time of its creation from among those given on the Psicrystal Personalities table. At 1st level, its owner typically gets a feel for a psicrystal&apos;s personality only through occasional impulses, but as the owner increases in level the psicrystal&apos;s personality becomes more pronounced.\n\nAt higher levels, it is not uncommon for a psicrystal to constantly ply its owner with observations and advice, often severely slanted toward the psicrystal&apos;s particular worldview. The owner always sees a bit of himself in his psicrystal, even if magnified and therefore distorted.\n\n{b}Note:{/b} The Sage personality is not fully implented yet and won&apos;t provide a bonus to single knowledge skill." compset="RaceSpec" summary="Every psicrystal has a personality.">
@@ -205,29 +205,29 @@ herofield[tHP].value = round(hitpoints/2,0,-1)</eval>
     <tag group="ChooseSrc1" tag="Hero"/>
     <tag group="ProductId" tag="HLCommunit"/>
     <eval phase="First" priority="10000"><![CDATA[
-~ If we're disabled, do nothing
-doneif (tagis[Helper.SpcDisable] <> 0)
-~ If we have not chosen then get out now
-doneif (field[usrChosen1].ischosen <> 1)
+      ~ If we're disabled, do nothing
+      doneif (tagis[Helper.SpcDisable] <> 0)
+      ~ If we have not chosen then get out now
+      doneif (field[usrChosen1].ischosen <> 1)
 
-perform field[usrChosen1].chosen.pulltags[PsicrysBon.?]
-perform field[usrChosen1].chosen.pulltags[PsicryType.?]
-perform field[usrChosen1].chosen.pulltags[PsicrystID.?]
+      perform field[usrChosen1].chosen.pulltags[PsicrysBon.?]
+      perform field[usrChosen1].chosen.pulltags[PsicryType.?]
+      perform field[usrChosen1].chosen.pulltags[PsicrystID.?]
 
-perform master.child[abPUAlertn].pushtags[PsicrysBon.?]
-perform master.child[abPUAlertn].pushtags[PsicryType.?]
-perform master.child[abPUAlertn].pushtags[PsicrystID.?]
+      perform master.child[abPUAlertn].pushtags[PsicrysBon.?]
+      perform master.child[abPUAlertn].pushtags[PsicryType.?]
+      perform master.child[abPUAlertn].pushtags[PsicrystID.?]
 
-~If bonus to one knowledge skill setup here by letting the 2nd
-~Personality racial ability select the knowledge skill.
-If (tagis[PsicryType.Other] + tagis[PsicrystID.Knowledge] = 2) Then
-   ~One Knowledge Skill bonus
-   field[usrCandid2].text = "component.BaseSkill & Helper.SkCatKnow"
-   ~Allow all knowledge skills to be chosen
-   perform assign[ChooseSrc2.Thing]
-   perform field[usrChosen2].chosen.pulltags[thingid.?,Reference]
-   perform master.child[abPUAlertn].pushtags[Reference.?]
-Endif]]></eval>
+      ~If bonus to one knowledge skill setup here by letting the 2nd
+      ~Personality racial ability select the knowledge skill.
+      If (tagis[PsicryType.Other] + tagis[PsicrystID.Knowledge] = 2) Then
+         ~One Knowledge Skill bonus
+         field[usrCandid2].text = "component.BaseSkill & Helper.SkCatKnow"
+         ~Allow all knowledge skills to be chosen
+         perform assign[ChooseSrc2.Thing]
+         perform field[usrChosen2].chosen.pulltags[thingid.?,Reference]
+         perform master.child[abPUAlertn].pushtags[Reference.?]
+      Endif]]></eval>
     </thing>
   <thing id="raPUShaPwr" name="Share Powers" description="At the owner&apos;s option, he can have any power (but not any psi-like ability) he manifests on himself also affect his psicrystal. The psicrystal must be within 5 feet of him at the time of the manifestation to receive the benefit. If the power has a duration other than instantaneous, it stops affecting the psicrystal if it moves farther than 5 feet away, and will not affect the psicrystal again, even if it returns to its owner before the duration expires.\n\nAdditionally, the owner can manifest a power with a target of &#147;You&#148; on his psicrystal (as a touch range power) instead of on himself. The owner and psicrystal cannot share powers if the powers normally do not affect creatures of the psicrystal&apos;s type (construct)." compset="RaceSpec">
     <tag group="AbilType" tag="Super"/>
@@ -258,12 +258,12 @@ Endif]]></eval>
     <tag group="AbilType" tag="Super"/>
     <tag group="ProductId" tag="HLCommunit"/>
     <eval phase="PostLevel" priority="10000"><![CDATA[
-~ If we're disabled, do nothing
-doneif (tagis[Helper.SpcDisable] <> 0)
+      ~ If we're disabled, do nothing
+      doneif (tagis[Helper.SpcDisable] <> 0)
 
-~ Set fly to 50ft and poor
-#value[xFly] += 50
-perform hero.child[xFly].assign[Maneuver.Poor]]]></eval>
+      ~ Set fly to 50ft and poor
+      #value[xFly] += 50
+      perform hero.child[xFly].assign[Maneuver.Poor]]]></eval>
     </thing>
   <thing id="raPUPwrRes" name="Power Resistance" description="If the owner is 11th level or higher, the psicrystal gains power resistance equal to the owner&apos;s level + 5. To affect the psicrystal with a power, another manifester must get a result on a manifester level check that equals or exceeds the psicrystal&apos;s power resistance." compset="RaceSpec">
     <fieldval field="abValue" value="5"/>
@@ -271,16 +271,16 @@ perform hero.child[xFly].assign[Maneuver.Poor]]]></eval>
     <tag group="SpecType" tag="Resist"/>
     <tag group="ProductId" tag="HLCommunit"/>
     <eval phase="PostLevel" priority="10000"><![CDATA[
-~ If we're disabled, do nothing
-doneif (tagis[Helper.SpcDisable] <> 0)
+      ~ If we're disabled, do nothing
+      doneif (tagis[Helper.SpcDisable] <> 0)
 
-~ Our bonus is 5 + Class levels
-field[abValue].value += master.hero.tagcount[Psionics.Class]
-~ Give any bonus levels like from "improved psicyrstal" feat
-field[abValue].value += master.hero.tagcount[Psicrystal.BonusLvl]
+      ~ Our bonus is 5 + Class levels
+      field[abValue].value += master.hero.tagcount[Psionics.Class]
+      ~ Give any bonus levels like from "improved psicyrstal" feat
+      field[abValue].value += master.hero.tagcount[Psicrystal.BonusLvl]
 
-~ Set the bonus on the Power Resistance Helper
-#applybonus[abValue,hero.child[xPwrRes],field[abValue].value]]]></eval>
+      ~ Set the bonus on the Power Resistance Helper
+      #applybonus[abValue,hero.child[xPwrRes],field[abValue].value]]]></eval>
     </thing>
   <thing id="raPUSigLnk" name="Sight Link" description="If the owner is 13th level or higher, the character can remote view the psicrystal (as if manifesting the remote view power) once per day." compset="RaceSpec">
     <fieldval field="trkMax" value="1"/>
@@ -304,32 +304,33 @@ field[abValue].value += master.hero.tagcount[Psicrystal.BonusLvl]
     <tag group="Helper" tag="ShowSpec"/>
     <tag group="ProductId" tag="HLCommunit"/>
     <eval phase="First" priority="1000"><![CDATA[
-~ If we're disabled, do nothing
-doneif (tagis[Helper.SpcDisable] <> 0)
-~ If we're not activated, just get out now
-doneif (field[abilActive].value <> 1)
+      ~ If we're disabled, do nothing
+      doneif (tagis[Helper.SpcDisable] <> 0)
+      ~ If we're not activated, just get out now
+      doneif (field[abilActive].value <> 1)
 
-~ We do have an STR and DEX score when Active
-perform hero.child[aSTR].delete[Helper.NoScore]
-perform hero.child[aDEX].delete[Helper.NoScore]
+      ~ We do have an STR and DEX score when Active
+      perform hero.child[aSTR].delete[Helper.NoScore]
+      perform hero.child[aDEX].delete[Helper.NoScore]
 
-~ Force our Strength to 1 and our Dexterity to 15
-hero.child[aSTR].field[aNormForce].value = 1
-hero.child[aDEX].field[aNormForce].value = 15
+      ~ Force our Strength to 1 and our Dexterity to 15
+      hero.child[aSTR].field[aNormForce].value = 1
+      hero.child[aDEX].field[aNormForce].value = 15
 
-~ set base speed to 30
-hero.child[Speed].field[tSpeed].value = 30
+      ~ set base speed to 30
+      hero.child[Speed].field[tSpeed].value = 30
 
-~ set climb speed to 20
-#value[xClimb] = maximum(20, #value[xClimb])
+      ~ set climb speed to 20
+      #value[xClimb] = maximum(20, #value[xClimb])
 
-~ Change the attributes on Climb
-perform hero.child[skClimb].assign[SkillOver.aDEX]]]></eval>
+      ~ Change the attributes on Climb
+      perform hero.child[skClimb].assign[SkillOver.aDEX]]]></eval>
     </thing>
   <thing id="minPUPsicr" name="Psicrystal" description="A psicrystal is a fragment of a psionic character&apos;s personality, brought into physical form and a semblance of life (via the Psicrystal Affinity feat). A psicrystal appears as a crystalline construct about the size of a human hand.{br}{br}Because it is an extension of its creator&apos;s personality, a character&apos;s psicrystal is in some ways a part of him.{br}{br}That&apos;s why, for example, a psionic character can manifest a personal range power on his psicrystal even though normally he can manifest such a power only on himself.{br}{br}A psicrystal is treated as a construct for the purposes of all effects that depend on its type.{br}{br}A psicrystal grants special abilities to its owner, as shown on the Psicrystal Special Abilities table below. In addition, a psicrystal has a personality (being a fragment of the owner&apos;s personality), which gives its owner a bonus on certain types of checks or saving throws, as given on the Psicrystal Personalities table below. These special abilities and bonuses apply only when the owner and the psicrystal are within 1 mile of each other.{br}{br}Psicrystal abilities are based on the owner&apos;s levels in psionic classes. Levels from other classes do not count toward the owner&apos;s level for purposes of psicrystal abilities.{br}{br}A psicrystal can speak one language of its owner&apos;s choice (so long as it is a language the owner knows). A psicrystal can understand all other languages known by its owner, but cannot speak them. This is a supernatural ability." compset="Minion" stacking="never">
     <usesource source="pPsiUn"/>
+    <tag group="gType" tag="PUPsionics"/>
     <tag group="gType" tag="PUPsicrsta"/>
-    <tag group="Helper" tag="NoPathSoc" name="Not Allowed for Pathfinder Society Characters" abbrev="Not Allowed for Pathfinder Society Characters"/>
+    <tag group="Helper" tag="NoPathSoc"/>
     <bootstrap thing="abPUAlertn"></bootstrap>
     <bootstrap thing="abPUDeToPo">
       <containerreq phase="First" priority="495"><![CDATA[count:Psionics.Class + count:Psicrystal.BonusLvl >= 3]]></containerreq>
@@ -337,8 +338,8 @@ perform hero.child[skClimb].assign[SkillOver.aDEX]]]></eval>
     <bootstrap thing="abPUSharPo"></bootstrap>
     <bootstrap thing="abPUTeleLi"></bootstrap>
     <exprreq message="Psicrystal not allowed."><![CDATA[hero.tagis[Psicrystal.Allowed] <> 0]]></exprreq>
-    <minion id="Mount">
-      <tag group="Hero" tag="FixedRace" name="FixedRace" abbrev="FixedRace"/>
+    <minion id="PUPsicrys">
+      <tag group="Hero" tag="FixedRace"/>
       <bootstrap thing="rPUPsicrys"></bootstrap>
       </minion>
     </thing>

--- a/COM_3PPPack_UltimatePsionics - Races Monster.user
+++ b/COM_3PPPack_UltimatePsionics - Races Monster.user
@@ -1047,58 +1047,30 @@ perform forward[Alignment.?]</eval>
     <bootstrap thing="raDelTouch">
       <containerreq phase="First" priority="5000"><![CDATA[fieldval:anCompLev >= 3]]></containerreq>
       </bootstrap>
-    <eval phase="Final" priority="5000" index="2"><![CDATA[hero.child[raPsicrPer].field[livename].text = "Personality (Artiste)"
-~hero.field[tAlign].text = master.field[tAlign].text]]></eval>
+    <eval phase="Final" priority="5000" index="2"><![CDATA[
+      hero.child[raPsicrPer].field[livename].text = "Personality (Artiste)"
+      ~hero.field[tAlign].text = master.field[tAlign].text]]></eval>
     <eval phase="PreLevel" priority="10000" index="3"><![CDATA[
-~ If we're a familiar, and we're close, give our master a skill bonus
-if (#isfamiliarwithin1mile[]) then
-  master.child[skSenseMot].field[Bonus].value += 3
-  endif]]></eval>
-    <eval phase="First" priority="1000">#skillbonus[skPercep] += 6
-#skillbonus[skStealth] -= 8
-hero.child[ArmorClass].field[tACNatural].value -=1
+      ~ If we're a familiar, and we're close, give our master a skill bonus
+      if (#isfamiliarwithin1mile[]) then
+        master.child[skSenseMot].field[Bonus].value += 3
+      endif]]></eval>
+    <eval phase="First" priority="1000"><![CDATA[
+      ~ Set skill bonuses &
+      #skillbonus[skPercep] += 6
+      #skillbonus[skStealth] -= 8
+      hero.child[ArmorClass].field[tACNatural].value -=1
 
-perform delete[Alignment.?]
-perform master.pulltags[Alignment.?]
-perform forward[Alignment.?]</eval>
-    </thing>
-  <thing id="rAstralC1" name="Astral Construct I" compset="Race">
-    <fieldval field="rHitDice" value="1"/>
-    <fieldval field="rSTR" value="5"/>
-    <fieldval field="rDEX" value="5"/>
-    <fieldval field="rWIS" value="1"/>
-    <fieldval field="rEnviron" value="Any"/>
-    <fieldval field="rOrgan" value="Solitary"/>
-    <fieldval field="rTreasure" value="None"/>
-    <fieldval field="rSpace" value="5"/>
-    <fieldval field="rReach" value="5"/>
-    <fieldval field="rAC" value="5"/>
-    <fieldval field="rHPStart" value="5"/>
-    <fieldval field="rGiveSpec" value="1"/>
-    <fieldval field="shortname" value="Astral Construct"/>
-    <usesource source="pPsiUn"/>
-    <tag group="HasType" tag="tpConstAst"/>
-    <tag group="RaceType" tag="Animal"/>
-    <tag group="CompIs" tag="cArcFamil"/>
-    <tag group="CompList" tag="AstralCons" name="Astral Construct"/>
-    <tag group="RaceSize" tag="Small11"/>
-    <tag group="Alignment" tag="NeutralLC"/>
-    <tag group="Alignment" tag="NeutralGE"/>
-    <tag group="NoScore" tag="aCON"/>
-    <tag group="NoScore" tag="aINT"/>
-    <tag group="AllowRCust" tag="MenuA" name="Menu A"/>
-    <bootstrap thing="tpConstAst"></bootstrap>
-    <bootstrap thing="wSlam">
-      <autotag group="wMain" tag="1d4_4"/>
-      <autotag group="Helper" tag="NatPrimary"/>
-      </bootstrap>
+      perform delete[Alignment.?]
+      perform master.pulltags[Alignment.?]
+      perform forward[Alignment.?]]]></eval>
     </thing>
   <thing id="tpConstAst" name="Construct (Astral)" description="A construct is an animated object or artificially created creature.\n\n{b}Traits{/b}: A construct possesses the following traits (unless otherwise noted in a creature&apos;s entry).\n* No Constitution score. Any DCs or other statistics that rely on a Constitution score treat a construct as having a score of 10 (no bonus or penalty).\n* Immunity to all mind-affecting effects (charms, compulsions, morale effects, patterns, and phantasms).\n* Immunity to bleed, disease, death effects, necromancy effects, paralysis, poison, sleep effects, and stunning.\n* Cannot heal damage on its own, but often can be repaired via exposure to a certain kind of effect (see the creature&apos;s description for details) or through the use of the Craft Construct feat. Constructs can also be healed through spells such as make whole. A construct with the Good healing special quality still benefits from that quality.\n* Not subject to ability damage, ability drain, fatigue, exhaustion, energy drain, or nonlethal damage.\n* Immunity to any effect that requires a Fortitude save (unless the effect also works on objects, or is harmless).\n* Not at risk of death from massive damage. Immediately destroyed when reduced to 0 hit points or less.\n* A construct cannot be raised or resurrected.\n* A construct is hard to destroy, and gains bonus hit points based on size, as shown on the following table. Construct Size Bonus Hit Points Fine ? Diminutive ? Tiny ? Small 10 Medium 20 Large 30 Huge 40 Gargantuan 60 Colossal 80\n* Proficient with its natural weapons only, unless generally humanoid in form, in which case proficient with any weapon mentioned in its entry.\n* Proficient with no armor.\n* Constructs do not breathe, eat, or sleep." compset="Type">
     <fieldval field="tpHDSides" value="10"/>
     <usesource source="pPsiUn"/>
-    <tag group="cAttack" tag="Good" name="Fast" abbrev="Fast"/>
+    <tag group="cAttack" tag="Good"/>
     <tag group="Type" tag="tpConst"/>
-    <tag group="NotLiving" tag="Construct" name="Construct" abbrev="Construct"/>
+    <tag group="NotLiving" tag="Construct"/>
     <bootstrap thing="xImmBleed">
       <containerreq phase="First" priority="600" name="Bootstrap Type Abilities"><![CDATA[
         (HasType.tpConstPsi | OverType.tpConstPsi) & !NoTypeAbil.tpConstPsi]]>
@@ -1190,15 +1162,75 @@ perform forward[Alignment.?]</eval>
         </containerreq>
       </bootstrap>
     </thing>
-  <thing id="rcMnuABuff" name="Buff" description="The astral construct gains an extra 5 hit points." compset="RaceCustom">
-    <fieldval field="abValue" value="5"/>
-    <usesource source="pPsiUn"/>
-    <tag group="AbilType" tag="Extra"/>
-    <tag group="CustomCost" tag="1"/>
-    <tag group="AllowRCust" tag="MenuA"/>
-    <eval phase="Final" priority="1000">herofield[tHP].value += field[abValue].value</eval>
+  <thing id="raPUAstCon" name="Astral Construct" description="When manifesting the astral construct power, the manifester assembles the desired creature from a menu of choices, as specified in the construct’s statistics block. A manifester can always substitute two choices from a lesser menu for one of its given abilities. Multiple selections of the same menu choice do not stack unless the ability specifically notes that stacking is allowed.\n\nSome menu choices grant an astral construct the ability to manifest specific powers as psi-like abilities. Unless using the ability is a free action, an astral construct manifesting such a power does so as a standard action that provokes attacks of opportunity. All such powers have a manifester level equal to the astral construct’s Hit Dice or the creator’s manifester level, whichever is lower.\n\nAn astral construct does not need to meet the prerequisites for a feat granted by a menu choice.\n\n{b}Note:{/b} To work correctl in HL the Menu choices have been broken down into a point buy system.  This allows for selecting different combinations of abilities correctly.\nMenu A - 1 Point abilities\nMenu B - 2 Point abilities\nMenu C - 4 Point abilities" compset="RaceSpec" summary="Menu A - 1 Point abilities; Menu B - 2 Point abilities; Menu C - 4 Point abilities">
+    <tag group="ProductId" tag="HLCommunit"/>
+    <eval phase="PreLevel" priority="25000" index="1"><![CDATA[
+      ~ If we're disabled, do nothing
+      doneif (tagis[Helper.SpcDisable] <> 0)
+      ~ If no bonus ability choices then get out now!
+      doneif (hero.tagis[Psionics.AstConMenu] = 0)
+
+      ~ Increase the number of Menu Ability Choices by the
+      ~ the number of tags. In addition only increase based on
+      ~ the highest menu letter.
+      ~ Menu A is 1 per tag
+      If (root.tagis[AllowRCust.PUMenuA] = 1) Then
+        root.field[rGiveSpec].value += 1 * hero.tagcount[Psionics.AstConMenu]
+
+      ~..Menu B is 2 per tag
+      ElseIf (root.tagis[AllowRCust.PUMenuB] = 1) Then
+        root.field[rGiveSpec].value += 2 * hero.tagcount[Psionics.AstConMenu]
+
+      ~..Menu C is 4 per tag
+      ElseIf (root.tagis[AllowRCust.PUMenuC] = 1) Then
+        root.field[rGiveSpec].value += 4 * hero.tagcount[Psionics.AstConMenu]
+      Endif]]></eval>
+    <eval phase="Final" priority="10000" index="2"><![CDATA[
+      ~ If we're disabled, do nothing
+      doneif (tagis[Helper.SpcDisable] <> 0)
+
+      ~ Setup live name to include the allowed Menu letters
+      field[livename].text = field[thingname].text & " (Menu " & root.tagabbrevs[AllowRCust.PUMenu?,","] & ")"
+
+      ~ Setup custom ability name
+      root.field[rSpecSing].text = "(Menu " & root.tagabbrevs[AllowRCust.PUMenu?," or "] & ") abilities"]]></eval>
     </thing>
-  <thing id="rAstralC2" name="Astral Construct II" compset="Race">
+  <thing id="rAstralC1" name="Astral Construct 1" description="Astral constructs are brought into being by the metacreativity power {i}astral construct{/i}. They are formed from raw ectoplasm (a portion of the astral medium drawn into the Material Plane). The power points spent by the construct’s creator during the manifestation of the power determine the level of the astral construct created. However, even astral constructs of the same level vary somewhat from each other, depending on the whims of their creators." compset="Race">
+    <fieldval field="rHitDice" value="1"/>
+    <fieldval field="rSTR" value="5"/>
+    <fieldval field="rDEX" value="5"/>
+    <fieldval field="rWIS" value="1"/>
+    <fieldval field="rEnviron" value="Any"/>
+    <fieldval field="rOrgan" value="Solitary"/>
+    <fieldval field="rTreasure" value="None"/>
+    <fieldval field="rSpace" value="5"/>
+    <fieldval field="rReach" value="5"/>
+    <fieldval field="rAC" value="5"/>
+    <fieldval field="rHPStart" value="5"/>
+    <fieldval field="rGiveSpec" value="1"/>
+    <fieldval field="shortname" value="Astral Construct"/>
+    <fieldval field="srcPageNum" value="444"/>
+    <fieldval field="srcBookInf" value="Ultimate Psionics"/>
+    <usesource source="pPsiUn"/>
+    <tag group="CompIs" tag="cArcFamil"/>
+    <tag group="CompList" tag="AstralCons" name="Astral Construct"/>
+    <tag group="RaceSize" tag="Small11"/>
+    <tag group="Alignment" tag="NeutralLC"/>
+    <tag group="Alignment" tag="NeutralGE"/>
+    <tag group="NoScore" tag="aCON"/>
+    <tag group="NoScore" tag="aINT"/>
+    <tag group="AllowRCust" tag="PUMenuA"/>
+    <tag group="ProductId" tag="HLCommunit"/>
+    <tag group="RaceType" tag="Animal"/>
+    <tag group="HasType" tag="tpConstAst"/>
+    <bootstrap thing="tpConstAst"></bootstrap>
+    <bootstrap thing="raPUAstCon"></bootstrap>
+    <bootstrap thing="wSlam">
+      <autotag group="wMain" tag="1d4_4"/>
+      <autotag group="Helper" tag="NatPrimary"/>
+      </bootstrap>
+    </thing>
+  <thing id="rAstralC2" name="Astral Construct 2" description="Astral constructs are brought into being by the metacreativity power {i}astral construct{/i}. They are formed from raw ectoplasm (a portion of the astral medium drawn into the Material Plane). The power points spent by the construct’s creator during the manifestation of the power determine the level of the astral construct created. However, even astral constructs of the same level vary somewhat from each other, depending on the whims of their creators." compset="Race">
     <fieldval field="rDEX" value="5"/>
     <fieldval field="rWIS" value="1"/>
     <fieldval field="rEnviron" value="Any"/>
@@ -1213,24 +1245,28 @@ perform forward[Alignment.?]</eval>
     <fieldval field="rAC" value="6"/>
     <fieldval field="rSpeed" value="40"/>
     <fieldval field="rHPStart" value="11"/>
+    <fieldval field="srcPageNum" value="444"/>
+    <fieldval field="srcBookInf" value="Ultimate Psionics"/>
     <usesource source="pPsiUn"/>
     <tag group="Alignment" tag="NeutralGE"/>
     <tag group="NoScore" tag="aCON"/>
     <tag group="NoScore" tag="aINT"/>
-    <tag group="AllowRCust" tag="MenuA" name="Menu A"/>
+    <tag group="AllowRCust" tag="PUMenuA"/>
     <tag group="RaceSize" tag="Medium0"/>
     <tag group="HasType" tag="tpConstAst"/>
     <tag group="RaceType" tag="Animal"/>
     <tag group="CompIs" tag="cArcFamil"/>
     <tag group="CompList" tag="AstralCons" name="Astral Construct"/>
     <tag group="Alignment" tag="NeutralLC"/>
+    <tag group="ProductId" tag="HLCommunit"/>
     <bootstrap thing="tpConstAst"></bootstrap>
+    <bootstrap thing="raPUAstCon"></bootstrap>
     <bootstrap thing="wSlam">
       <autotag group="wMain" tag="1d4_4"/>
       <autotag group="Helper" tag="NatPrimary"/>
       </bootstrap>
     </thing>
-  <thing id="rAstralC3" name="Astral Construct III" compset="Race">
+  <thing id="rAstralC3" name="Astral Construct 3" description="Astral constructs are brought into being by the metacreativity power {i}astral construct{/i}. They are formed from raw ectoplasm (a portion of the astral medium drawn into the Material Plane). The power points spent by the construct’s creator during the manifestation of the power determine the level of the astral construct created. However, even astral constructs of the same level vary somewhat from each other, depending on the whims of their creators." compset="Race">
     <fieldval field="rDEX" value="5"/>
     <fieldval field="rWIS" value="1"/>
     <fieldval field="rEnviron" value="Any"/>
@@ -1245,6 +1281,8 @@ perform forward[Alignment.?]</eval>
     <fieldval field="rHPStart" value="16"/>
     <fieldval field="rSTR" value="11"/>
     <fieldval field="rAC" value="8"/>
+    <fieldval field="srcPageNum" value="444"/>
+    <fieldval field="srcBookInf" value="Ultimate Psionics"/>
     <usesource source="pPsiUn"/>
     <tag group="RaceSize" tag="Medium0"/>
     <tag group="HasType" tag="tpConstAst"/>
@@ -1252,17 +1290,19 @@ perform forward[Alignment.?]</eval>
     <tag group="CompIs" tag="cArcFamil"/>
     <tag group="CompList" tag="AstralCons" name="Astral Construct"/>
     <tag group="Alignment" tag="NeutralLC"/>
-    <tag group="AllowRCust" tag="MenuA" name="Menu A"/>
+    <tag group="AllowRCust" tag="PUMenuA"/>
     <tag group="Alignment" tag="NeutralGE"/>
     <tag group="NoScore" tag="aCON"/>
     <tag group="NoScore" tag="aINT"/>
+    <tag group="ProductId" tag="HLCommunit"/>
     <bootstrap thing="tpConstAst"></bootstrap>
+    <bootstrap thing="raPUAstCon"></bootstrap>
     <bootstrap thing="wSlam">
       <autotag group="wMain" tag="1d4_4"/>
       <autotag group="Helper" tag="NatPrimary"/>
       </bootstrap>
     </thing>
-  <thing id="rAstralC4" name="Astral Construct IV" compset="Race">
+  <thing id="rAstralC4" name="Astral Construct 4" description="Astral constructs are brought into being by the metacreativity power {i}astral construct{/i}. They are formed from raw ectoplasm (a portion of the astral medium drawn into the Material Plane). The power points spent by the construct’s creator during the manifestation of the power determine the level of the astral construct created. However, even astral constructs of the same level vary somewhat from each other, depending on the whims of their creators." compset="Race">
     <fieldval field="rDEX" value="5"/>
     <fieldval field="rWIS" value="1"/>
     <fieldval field="rEnviron" value="Any"/>
@@ -1277,6 +1317,8 @@ perform forward[Alignment.?]</eval>
     <fieldval field="rHPStart" value="27"/>
     <fieldval field="rSTR" value="15"/>
     <fieldval field="rAC" value="10"/>
+    <fieldval field="srcPageNum" value="444"/>
+    <fieldval field="srcBookInf" value="Ultimate Psionics"/>
     <usesource source="pPsiUn"/>
     <tag group="RaceSize" tag="Medium0"/>
     <tag group="HasType" tag="tpConstAst"/>
@@ -1284,18 +1326,20 @@ perform forward[Alignment.?]</eval>
     <tag group="CompIs" tag="cArcFamil"/>
     <tag group="CompList" tag="AstralCons" name="Astral Construct"/>
     <tag group="Alignment" tag="NeutralLC"/>
-    <tag group="AllowRCust" tag="MenuA" name="Menu A"/>
+    <tag group="AllowRCust" tag="PUMenuA"/>
     <tag group="Alignment" tag="NeutralGE"/>
     <tag group="NoScore" tag="aCON"/>
     <tag group="NoScore" tag="aINT"/>
-    <tag group="AllowRCust" tag="MenuB"/>
+    <tag group="AllowRCust" tag="PUMenuB"/>
+    <tag group="ProductId" tag="HLCommunit"/>
     <bootstrap thing="tpConstAst"></bootstrap>
+    <bootstrap thing="raPUAstCon"></bootstrap>
     <bootstrap thing="wSlam">
       <autotag group="wMain" tag="1d4_4"/>
       <autotag group="Helper" tag="NatPrimary"/>
       </bootstrap>
     </thing>
-  <thing id="rAstralC5" name="Astral Construct V" compset="Race">
+  <thing id="rAstralC5" name="Astral Construct 5" description="Astral constructs are brought into being by the metacreativity power {i}astral construct{/i}. They are formed from raw ectoplasm (a portion of the astral medium drawn into the Material Plane). The power points spent by the construct’s creator during the manifestation of the power determine the level of the astral construct created. However, even astral constructs of the same level vary somewhat from each other, depending on the whims of their creators." compset="Race">
     <fieldval field="rWIS" value="1"/>
     <fieldval field="rEnviron" value="Any"/>
     <fieldval field="rOrgan" value="Solitary"/>
@@ -1310,6 +1354,8 @@ perform forward[Alignment.?]</eval>
     <fieldval field="rSTR" value="19"/>
     <fieldval field="rAC" value="13"/>
     <fieldval field="rDEX" value="3"/>
+    <fieldval field="srcPageNum" value="444"/>
+    <fieldval field="srcBookInf" value="Ultimate Psionics"/>
     <usesource source="pPsiUn"/>
     <tag group="HasType" tag="tpConstAst"/>
     <tag group="RaceType" tag="Animal"/>
@@ -1320,9 +1366,11 @@ perform forward[Alignment.?]</eval>
     <tag group="NoScore" tag="aCON"/>
     <tag group="NoScore" tag="aINT"/>
     <tag group="RaceSize" tag="Large1"/>
-    <tag group="AllowRCust" tag="MenuA"/>
-    <tag group="AllowRCust" tag="MenuB"/>
+    <tag group="AllowRCust" tag="PUMenuA"/>
+    <tag group="AllowRCust" tag="PUMenuB"/>
+    <tag group="ProductId" tag="HLCommunit"/>
     <bootstrap thing="tpConstAst"></bootstrap>
+    <bootstrap thing="raPUAstCon"></bootstrap>
     <bootstrap thing="xDamRdMag">
       <assignval field="abValue" value="5"/>
       </bootstrap>
@@ -1332,7 +1380,7 @@ perform forward[Alignment.?]</eval>
       <autotag group="Value" tag="2"/>
       </bootstrap>
     </thing>
-  <thing id="rAstralC6" name="Astral Construct VI" compset="Race">
+  <thing id="rAstralC6" name="Astral Construct 6" description="Astral constructs are brought into being by the metacreativity power {i}astral construct{/i}. They are formed from raw ectoplasm (a portion of the astral medium drawn into the Material Plane). The power points spent by the construct’s creator during the manifestation of the power determine the level of the astral construct created. However, even astral constructs of the same level vary somewhat from each other, depending on the whims of their creators." compset="Race">
     <fieldval field="rWIS" value="1"/>
     <fieldval field="rEnviron" value="Any"/>
     <fieldval field="rOrgan" value="Solitary"/>
@@ -1347,19 +1395,23 @@ perform forward[Alignment.?]</eval>
     <fieldval field="rSTR" value="23"/>
     <fieldval field="rAC" value="15"/>
     <fieldval field="rDEX" value="3"/>
+    <fieldval field="srcPageNum" value="444"/>
+    <fieldval field="srcBookInf" value="Ultimate Psionics"/>
     <usesource source="pPsiUn"/>
     <tag group="HasType" tag="tpConstAst"/>
     <tag group="RaceType" tag="Animal"/>
     <tag group="CompIs" tag="cArcFamil"/>
     <tag group="CompList" tag="AstralCons" name="Astral Construct"/>
     <tag group="Alignment" tag="NeutralLC"/>
-    <tag group="AllowRCust" tag="MenuA" name="Menu A"/>
+    <tag group="AllowRCust" tag="PUMenuA"/>
     <tag group="Alignment" tag="NeutralGE"/>
     <tag group="NoScore" tag="aCON"/>
     <tag group="NoScore" tag="aINT"/>
     <tag group="RaceSize" tag="Large1"/>
-    <tag group="AllowRCust" tag="MenuB"/>
+    <tag group="AllowRCust" tag="PUMenuB"/>
+    <tag group="ProductId" tag="HLCommunit"/>
     <bootstrap thing="tpConstAst"></bootstrap>
+    <bootstrap thing="raPUAstCon"></bootstrap>
     <bootstrap thing="xDamRdMag">
       <assignval field="abValue" value="10"/>
       </bootstrap>
@@ -1369,7 +1421,7 @@ perform forward[Alignment.?]</eval>
       <autotag group="Value" tag="2"/>
       </bootstrap>
     </thing>
-  <thing id="rAstralC7" name="Astral Construct VII" compset="Race">
+  <thing id="rAstralC7" name="Astral Construct 7" description="Astral constructs are brought into being by the metacreativity power {i}astral construct{/i}. They are formed from raw ectoplasm (a portion of the astral medium drawn into the Material Plane). The power points spent by the construct’s creator during the manifestation of the power determine the level of the astral construct created. However, even astral constructs of the same level vary somewhat from each other, depending on the whims of their creators." compset="Race">
     <fieldval field="rWIS" value="1"/>
     <fieldval field="rEnviron" value="Any"/>
     <fieldval field="rOrgan" value="Solitary"/>
@@ -1384,20 +1436,24 @@ perform forward[Alignment.?]</eval>
     <fieldval field="rDEX" value="3"/>
     <fieldval field="rHPStart" value="81"/>
     <fieldval field="rGiveSpec" value="4"/>
+    <fieldval field="srcPageNum" value="444"/>
+    <fieldval field="srcBookInf" value="Ultimate Psionics"/>
     <usesource source="pPsiUn"/>
     <tag group="Alignment" tag="NeutralLC"/>
-    <tag group="AllowRCust" tag="MenuA" name="Menu A"/>
+    <tag group="AllowRCust" tag="PUMenuA"/>
     <tag group="Alignment" tag="NeutralGE"/>
     <tag group="NoScore" tag="aCON"/>
     <tag group="NoScore" tag="aINT"/>
     <tag group="RaceSize" tag="Large1"/>
     <tag group="RaceType" tag="Animal"/>
     <tag group="HasType" tag="tpConstAst"/>
-    <tag group="AllowRCust" tag="MenuB" name="Menu B"/>
-    <tag group="AllowRCust" tag="MenuC" name="Menu C"/>
+    <tag group="AllowRCust" tag="PUMenuB"/>
+    <tag group="AllowRCust" tag="PUMenuC"/>
     <tag group="CompIs" tag="cArcFamil"/>
     <tag group="CompList" tag="AstralCons"/>
+    <tag group="ProductId" tag="HLCommunit"/>
     <bootstrap thing="tpConstAst"></bootstrap>
+    <bootstrap thing="raPUAstCon"></bootstrap>
     <bootstrap thing="wSlam">
       <autotag group="wMain" tag="1d8_6"/>
       <autotag group="Helper" tag="NatPrimary"/>
@@ -1407,7 +1463,7 @@ perform forward[Alignment.?]</eval>
       <assignval field="abValue" value="10"/>
       </bootstrap>
     </thing>
-  <thing id="rAstralC8" name="Astral Construct VIII" compset="Race">
+  <thing id="rAstralC8" name="Astral Construct 8" description="Astral constructs are brought into being by the metacreativity power {i}astral construct{/i}. They are formed from raw ectoplasm (a portion of the astral medium drawn into the Material Plane). The power points spent by the construct’s creator during the manifestation of the power determine the level of the astral construct created. However, even astral constructs of the same level vary somewhat from each other, depending on the whims of their creators." compset="Race">
     <fieldval field="rWIS" value="1"/>
     <fieldval field="rEnviron" value="Any"/>
     <fieldval field="rOrgan" value="Solitary"/>
@@ -1422,20 +1478,24 @@ perform forward[Alignment.?]</eval>
     <fieldval field="rDEX" value="3"/>
     <fieldval field="rHPStart" value="81"/>
     <fieldval field="rGiveSpec" value="4"/>
+    <fieldval field="srcBookInf" value="Ultimate Psionics"/>
+    <fieldval field="srcPageNum" value="444"/>
     <usesource source="pPsiUn"/>
-    <tag group="Alignment" tag="NeutralLC"/>
-    <tag group="AllowRCust" tag="MenuA" name="Menu A"/>
     <tag group="Alignment" tag="NeutralGE"/>
     <tag group="NoScore" tag="aCON"/>
     <tag group="NoScore" tag="aINT"/>
     <tag group="RaceSize" tag="Large1"/>
     <tag group="RaceType" tag="Animal"/>
     <tag group="HasType" tag="tpConstAst"/>
-    <tag group="AllowRCust" tag="MenuB" name="Menu B"/>
-    <tag group="AllowRCust" tag="MenuC" name="Menu C"/>
+    <tag group="AllowRCust" tag="PUMenuA"/>
+    <tag group="AllowRCust" tag="PUMenuB"/>
+    <tag group="AllowRCust" tag="PUMenuC"/>
     <tag group="CompIs" tag="cArcFamil"/>
     <tag group="CompList" tag="AstralCons"/>
+    <tag group="ProductId" tag="HLCommunit"/>
+    <tag group="Alignment" tag="NeutralLC"/>
     <bootstrap thing="tpConstAst"></bootstrap>
+    <bootstrap thing="raPUAstCon"></bootstrap>
     <bootstrap thing="wSlam">
       <autotag group="wMain" tag="1d8_6"/>
       <autotag group="Helper" tag="NatPrimary"/>
@@ -1445,7 +1505,7 @@ perform forward[Alignment.?]</eval>
       <assignval field="abValue" value="15"/>
       </bootstrap>
     </thing>
-  <thing id="rAstralC9" name="Astral Construct IX" compset="Race">
+  <thing id="rAstralC9" name="Astral Construct 9" description="Astral constructs are brought into being by the metacreativity power {i}astral construct{/i}. They are formed from raw ectoplasm (a portion of the astral medium drawn into the Material Plane). The power points spent by the construct’s creator during the manifestation of the power determine the level of the astral construct created. However, even astral constructs of the same level vary somewhat from each other, depending on the whims of their creators." compset="Race">
     <fieldval field="rWIS" value="1"/>
     <fieldval field="rEnviron" value="Any"/>
     <fieldval field="rOrgan" value="Solitary"/>
@@ -1460,20 +1520,24 @@ perform forward[Alignment.?]</eval>
     <fieldval field="rDEX" value="1"/>
     <fieldval field="rSpeed" value="50"/>
     <fieldval field="rGiveSpec" value="8"/>
+    <fieldval field="srcPageNum" value="444"/>
+    <fieldval field="srcBookInf" value="Ultimate Psionics"/>
     <usesource source="pPsiUn"/>
     <tag group="RaceSize" tag="Huge2"/>
     <tag group="RaceType" tag="Animal"/>
     <tag group="HasType" tag="tpConstAst"/>
-    <tag group="AllowRCust" tag="MenuB" name="Menu B"/>
-    <tag group="AllowRCust" tag="MenuC" name="Menu C"/>
+    <tag group="AllowRCust" tag="PUMenuA"/>
+    <tag group="AllowRCust" tag="PUMenuB"/>
+    <tag group="AllowRCust" tag="PUMenuC"/>
     <tag group="CompIs" tag="cArcFamil"/>
     <tag group="CompList" tag="AstralCons"/>
     <tag group="NoScore" tag="aINT"/>
     <tag group="Alignment" tag="NeutralLC"/>
-    <tag group="AllowRCust" tag="MenuA" name="Menu A"/>
     <tag group="Alignment" tag="NeutralGE"/>
     <tag group="NoScore" tag="aCON"/>
+    <tag group="ProductId" tag="HLCommunit"/>
     <bootstrap thing="tpConstAst"></bootstrap>
+    <bootstrap thing="raPUAstCon"></bootstrap>
     <bootstrap thing="xDamRdMag">
       <assignval field="abValue" value="15"/>
       </bootstrap>
@@ -1483,11 +1547,19 @@ perform forward[Alignment.?]</eval>
       <autotag group="Value" tag="2"/>
       </bootstrap>
     </thing>
+  <thing id="rcMnuABuff" name="Buff" description="The astral construct gains an extra 5 hit points." compset="RaceCustom">
+    <fieldval field="abValue" value="5"/>
+    <usesource source="pPsiUn"/>
+    <tag group="AbilType" tag="Extra"/>
+    <tag group="CustomCost" tag="1"/>
+    <tag group="AllowRCust" tag="PUMenuA"/>
+    <eval phase="Final" priority="1000">herofield[tHP].value += field[abValue].value</eval>
+    </thing>
   <thing id="rcMnuACele" name="Celerity" description="The astral construct&apos;s land speed is increased by 10 feet." compset="RaceCustom">
     <fieldval field="abValue" value="10"/>
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="1"/>
-    <tag group="AllowRCust" tag="MenuA"/>
+    <tag group="AllowRCust" tag="PUMenuA"/>
     <tag group="AbilType" tag="Extra"/>
     <eval phase="Final">~ Add to our base speed.
 hero.child[Speed].field[tSpeed].value += field[abValue].value</eval>
@@ -1496,7 +1568,7 @@ hero.child[Speed].field[tSpeed].value += field[abValue].value</eval>
     <fieldval field="abValue" value="10"/>
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="1"/>
-    <tag group="AllowRCust" tag="MenuA"/>
+    <tag group="AllowRCust" tag="PUMenuA"/>
     <tag group="AbilType" tag="Extra"/>
     <bootstrap thing="fCleave">
       <autotag group="thing" tag="skipprereq"/>
@@ -1506,7 +1578,7 @@ hero.child[Speed].field[tSpeed].value += field[abValue].value</eval>
     <fieldval field="abValue" value="10"/>
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="2"/>
-    <tag group="AllowRCust" tag="MenuB"/>
+    <tag group="AllowRCust" tag="PUMenuB"/>
     <tag group="AbilType" tag="Extra"/>
     <bootstrap thing="xFly">
       <autotag group="Maneuver" tag="Average"/>
@@ -1517,7 +1589,7 @@ hero.child[Speed].field[tSpeed].value += field[abValue].value</eval>
     <fieldval field="abValue" value="10"/>
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="1"/>
-    <tag group="AllowRCust" tag="MenuA"/>
+    <tag group="AllowRCust" tag="PUMenuA"/>
     <tag group="AbilType" tag="Extra"/>
     <eval phase="Final">~ Add deflection bonus to AC.
 hero.child[ArmorClass].field[tACDeflect].value = maximum(hero.child[ArmorClass].field[tACDeflect].value, 1)</eval>
@@ -1525,7 +1597,7 @@ hero.child[ArmorClass].field[tACDeflect].value = maximum(hero.child[ArmorClass].
   <thing id="rcMnuAFly" name="Fly" description="The astral construct has physical wings and a fly speed of 20 feet (average)." compset="RaceCustom">
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="1"/>
-    <tag group="AllowRCust" tag="MenuA"/>
+    <tag group="AllowRCust" tag="PUMenuA"/>
     <tag group="AbilType" tag="Extra"/>
     <bootstrap thing="xFly">
       <autotag group="Maneuver" tag="Average"/>
@@ -1536,7 +1608,7 @@ hero.child[ArmorClass].field[tACDeflect].value = maximum(hero.child[ArmorClass].
     <fieldval field="abValue" value="10"/>
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="1"/>
-    <tag group="AllowRCust" tag="MenuA"/>
+    <tag group="AllowRCust" tag="PUMenuA"/>
     <tag group="AbilType" tag="Extra"/>
     <bootstrap thing="fImpBull">
       <autotag group="thing" tag="skipprereq"/>
@@ -1545,7 +1617,7 @@ hero.child[ArmorClass].field[tACDeflect].value = maximum(hero.child[ArmorClass].
   <thing id="rcMnuAINA" name="Improved Slam Attack" description="The astral construct gains the Improved Natural Attack feat." compset="RaceCustom">
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="1"/>
-    <tag group="AllowRCust" tag="MenuA"/>
+    <tag group="AllowRCust" tag="PUMenuA"/>
     <tag group="AbilType" tag="Extra"/>
     <bootstrap thing="fImpNatAtt">
       <autotag group="thing" tag="skipprereq"/>
@@ -1555,7 +1627,7 @@ hero.child[ArmorClass].field[tACDeflect].value = maximum(hero.child[ArmorClass].
   <thing id="rcMnuAMobi" name="Mobility" description="The astral construct gains the Mobility feat." compset="RaceCustom">
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="1"/>
-    <tag group="AllowRCust" tag="MenuA"/>
+    <tag group="AllowRCust" tag="PUMenuA"/>
     <tag group="AbilType" tag="Extra"/>
     <bootstrap thing="fMobility">
       <autotag group="thing" tag="skipprereq"/>
@@ -1564,7 +1636,7 @@ hero.child[ArmorClass].field[tACDeflect].value = maximum(hero.child[ArmorClass].
   <thing id="rcMnuAPwrA" name="Power Attack" description="The astral construct gains the Power Attack feat." compset="RaceCustom">
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="1"/>
-    <tag group="AllowRCust" tag="MenuA"/>
+    <tag group="AllowRCust" tag="PUMenuA"/>
     <tag group="AbilType" tag="Extra"/>
     <bootstrap thing="fPowerAtt">
       <autotag group="thing" tag="skipprereq"/>
@@ -1573,7 +1645,7 @@ hero.child[ArmorClass].field[tACDeflect].value = maximum(hero.child[ArmorClass].
   <thing id="rcMnuResF" name="Resistance (Fire)" description="The astral construct gains resistance 5 against Fire." compset="RaceCustom">
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="1"/>
-    <tag group="AllowRCust" tag="MenuA"/>
+    <tag group="AllowRCust" tag="PUMenuA"/>
     <tag group="AbilType" tag="Extra"/>
     <tag group="Helper" tag="SpecUp"/>
     <eval phase="First">#applyresist[xDamRsFire, 5]</eval>
@@ -1581,7 +1653,7 @@ hero.child[ArmorClass].field[tACDeflect].value = maximum(hero.child[ArmorClass].
   <thing id="rcMnuASwim" name="Swim" description="The astral construct is streamlined and shark like, and gains a swim speed of 30 feet." compset="RaceCustom">
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="1"/>
-    <tag group="AllowRCust" tag="MenuA"/>
+    <tag group="AllowRCust" tag="PUMenuA"/>
     <bootstrap thing="xSwim">
       <autotag group="Value" tag="30"/>
       </bootstrap>
@@ -1589,13 +1661,13 @@ hero.child[ArmorClass].field[tACDeflect].value = maximum(hero.child[ArmorClass].
   <thing id="rcMnuATrip" name="Trip" description="If the astral construct hits with a slam attack, it can attempt to trip the opponent as a free action without provoking attacks of opportunity. If the attempt fails, the opponent cannot react to trip the astral construct." compset="RaceCustom">
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="1"/>
-    <tag group="AllowRCust" tag="MenuA"/>
+    <tag group="AllowRCust" tag="PUMenuA"/>
     <tag group="AbilType" tag="Extra"/>
     </thing>
   <thing id="rcMunAResC" name="Resistance (Cold)" description="The astral construct gains resistance 5 against Cold." compset="RaceCustom">
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="1"/>
-    <tag group="AllowRCust" tag="MenuA"/>
+    <tag group="AllowRCust" tag="PUMenuA"/>
     <tag group="AbilType" tag="Extra"/>
     <tag group="Helper" tag="SpecUp"/>
     <eval phase="First">#applyresist[xDamRsCold, 5]</eval>
@@ -1603,7 +1675,7 @@ hero.child[ArmorClass].field[tACDeflect].value = maximum(hero.child[ArmorClass].
   <thing id="rcMnuAResA" name="Resistance (Acid)" description="The astral construct gains resistance 5 against Acid." compset="RaceCustom">
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="1"/>
-    <tag group="AllowRCust" tag="MenuA"/>
+    <tag group="AllowRCust" tag="PUMenuA"/>
     <tag group="AbilType" tag="Extra"/>
     <tag group="Helper" tag="SpecUp"/>
     <eval phase="First">#applyresist[xDamRsAcid, 5]</eval>
@@ -1611,7 +1683,7 @@ hero.child[ArmorClass].field[tACDeflect].value = maximum(hero.child[ArmorClass].
   <thing id="rcMnuAResE" name="Resistance (Electricity)" description="The astral construct gains resistance 5 against Electricity." compset="RaceCustom">
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="1"/>
-    <tag group="AllowRCust" tag="MenuA"/>
+    <tag group="AllowRCust" tag="PUMenuA"/>
     <tag group="AbilType" tag="Extra"/>
     <tag group="Helper" tag="SpecUp"/>
     <eval phase="First">#applyresist[xDamRsElec, 5]</eval>
@@ -1619,7 +1691,7 @@ hero.child[ArmorClass].field[tACDeflect].value = maximum(hero.child[ArmorClass].
   <thing id="rcMnuAResS" name="Resistance (Sonic)" description="The astral construct gains resistance 5 against Sonic." compset="RaceCustom">
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="1"/>
-    <tag group="AllowRCust" tag="MenuA"/>
+    <tag group="AllowRCust" tag="PUMenuA"/>
     <tag group="AbilType" tag="Extra"/>
     <tag group="Helper" tag="SpecUp"/>
     <eval phase="First">#applyresist[xDamRsSoni, 5]</eval>
@@ -1628,7 +1700,7 @@ hero.child[ArmorClass].field[tACDeflect].value = maximum(hero.child[ArmorClass].
     <fieldval field="abValue" value="10"/>
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="2"/>
-    <tag group="AllowRCust" tag="MenuB"/>
+    <tag group="AllowRCust" tag="PUMenuB"/>
     <eval phase="First" priority="20000">hero.child[aSTR].field[aNormMod].value -= 2
 hero.child[aDEX].field[aNormMod].value += 2
 
@@ -1641,7 +1713,7 @@ call SizeChange</eval>
     <fieldval field="abValue" value="10"/>
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="2"/>
-    <tag group="AllowRCust" tag="MenuB"/>
+    <tag group="AllowRCust" tag="PUMenuB"/>
     <tag group="AbilType" tag="Extra"/>
     <eval phase="First" priority="20000">hero.child[aSTR].field[aNormMod].value -= 2
 hero.child[aDEX].field[aNormMod].value += 2
@@ -1655,7 +1727,7 @@ call SizeChange</eval>
     <fieldval field="abValue" value="10"/>
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="2"/>
-    <tag group="AllowRCust" tag="MenuB"/>
+    <tag group="AllowRCust" tag="PUMenuB"/>
     <eval phase="PreLevel" priority="10000"><![CDATA[foreach pick in hero from BaseWep where "!thingid.wTouch & !thingid.wRay"
   perform eachpick.assign[Helper.ExtraHigh]
   nexteach
@@ -1670,14 +1742,14 @@ if (herofield[tSize].value > 0) then
     <fieldval field="abValue" value="10"/>
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="2"/>
-    <tag group="AllowRCust" tag="MenuB"/>
+    <tag group="AllowRCust" tag="PUMenuB"/>
     <tag group="AbilType" tag="Extra"/>
     </thing>
   <thing id="rcMnuBDefl" name="Heavy Deflection" description="The astral construct gains a +4 deflection bonus to Armor Class." compset="RaceCustom">
     <fieldval field="abValue" value="10"/>
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="2"/>
-    <tag group="AllowRCust" tag="MenuB"/>
+    <tag group="AllowRCust" tag="PUMenuB"/>
     <tag group="AbilType" tag="Extra"/>
     <eval phase="Final">~ Add deflection bonus to AC.
 hero.child[ArmorClass].field[tACDeflect].value = maximum(hero.child[ArmorClass].field[tACDeflect].value, 4)</eval>
@@ -1687,14 +1759,14 @@ hero.child[ArmorClass].field[tACDeflect].value = maximum(hero.child[ArmorClass].
     <usesource source="pPsiUn"/>
     <tag group="AbilType" tag="Extra"/>
     <tag group="CustomCost" tag="2"/>
-    <tag group="AllowRCust" tag="MenuB"/>
+    <tag group="AllowRCust" tag="PUMenuB"/>
     <eval phase="Final" priority="1000">herofield[tHP].value += field[abValue].value</eval>
     </thing>
   <thing id="rcMnuBImpC" name="Improved Critical" description="The astral construct gains the Improved Critical feat with its slam attacks." compset="RaceCustom">
     <usesource source="pPsiUn"/>
     <tag group="AbilType" tag="Extra"/>
     <tag group="CustomCost" tag="2"/>
-    <tag group="AllowRCust" tag="MenuB"/>
+    <tag group="AllowRCust" tag="PUMenuB"/>
     <bootstrap thing="fImpCrit">
       <autotag group="thing" tag="skipprereq"/>
       <autotag group="Target" tag="wSlam"/>
@@ -1704,7 +1776,7 @@ hero.child[ArmorClass].field[tACDeflect].value = maximum(hero.child[ArmorClass].
     <usesource source="pPsiUn"/>
     <tag group="AbilType" tag="Extra"/>
     <tag group="CustomCost" tag="2"/>
-    <tag group="AllowRCust" tag="MenuB"/>
+    <tag group="AllowRCust" tag="PUMenuB"/>
     <tag group="Helper" tag="SpecUp"/>
     <eval phase="Final">var myVal as number
 myVal = 0
@@ -1718,12 +1790,12 @@ myVal +=3
     <usesource source="pPsiUn"/>
     <tag group="AbilType" tag="Extra"/>
     <tag group="CustomCost" tag="2"/>
-    <tag group="AllowRCust" tag="MenuB"/>
+    <tag group="AllowRCust" tag="PUMenuB"/>
     </thing>
   <thing id="rcMnuBSwim" name="Improved Swim" description="The astral construct is streamlined and shark like, and gains a swim speed of 60 feet." compset="RaceCustom">
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="2"/>
-    <tag group="AllowRCust" tag="MenuB"/>
+    <tag group="AllowRCust" tag="PUMenuB"/>
     <bootstrap thing="xSwim">
       <autotag group="Value" tag="60"/>
       </bootstrap>
@@ -1732,7 +1804,7 @@ myVal +=3
     <fieldval field="abValue" value="10"/>
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="2"/>
-    <tag group="AllowRCust" tag="MenuB"/>
+    <tag group="AllowRCust" tag="PUMenuB"/>
     <tag group="AbilType" tag="Extra"/>
     <eval phase="First" priority="20000">hero.child[aSTR].field[aNormMod].value += 4</eval>
     </thing>
@@ -1740,19 +1812,19 @@ myVal +=3
     <fieldval field="abValue" value="10"/>
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="2"/>
-    <tag group="AllowRCust" tag="MenuB"/>
+    <tag group="AllowRCust" tag="PUMenuB"/>
     <tag group="AbilType" tag="Extra"/>
     </thing>
   <thing id="rcMnuBPoun" name="Pounce" description="If the astral construct charges a foe, it can make a full attack." compset="RaceCustom">
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="2"/>
-    <tag group="AllowRCust" tag="MenuB"/>
+    <tag group="AllowRCust" tag="PUMenuB"/>
     <tag group="AbilType" tag="Extra"/>
     </thing>
   <thing id="rcMnuBSmit" name="Smite" description="Once per day the astral construct can choose one target to focus on, dealing additional damage. The astral construct deals extra damage equal to its Hit Dice to this target until the target is dead, the astral construct&apos;s duration is destroyed, expired, or dimissed, or the manifester who summoned it rests to regain daily power points." compset="RaceCustom">
     <fieldval field="trkMax" value="1"/>
     <usesource source="pPsiUn"/>
-    <tag group="AllowRCust" tag="MenuB"/>
+    <tag group="AllowRCust" tag="PUMenuB"/>
     <tag group="AbilType" tag="Super"/>
     <tag group="User" tag="Tracker"/>
     <tag group="CustomCost" tag="2"/>
@@ -1761,7 +1833,7 @@ myVal +=3
   <thing id="rcMnuBTram" name="Trample" description="As a standard action during its turn each round, a Large or larger astral construct can literally run over an opponent at least one size smaller than itself. It merely has to move over the opponent to deal bludgeoning damage equal to 1d8 + its Str modifier. The target can attempt a Reflex save (DC 10 + 1/2 astral construct&apos;s Hit Dice + astral construct&apos;s Str modifier) to negate the damage, or it can instead choose to make an attack of opportunity at a –4 penalty." compset="RaceCustom">
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="2"/>
-    <tag group="AllowRCust" tag="MenuB"/>
+    <tag group="AllowRCust" tag="PUMenuB"/>
     <tag group="AbilType" tag="Extra"/>
     <exprreq message="Large+ size creature required."><![CDATA[herofield[tSize].value > 0]]></exprreq>
     </thing>
@@ -1769,7 +1841,7 @@ myVal +=3
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="4"/>
     <tag group="AbilType" tag="Extra"/>
-    <tag group="AllowRCust" tag="MenuC"/>
+    <tag group="AllowRCust" tag="PUMenuC"/>
     <bootstrap thing="rBlindSi">
       <autotag group="Value" tag="60"/>
       </bootstrap>
@@ -1777,7 +1849,7 @@ myVal +=3
   <thing id="rcMnuCConc" name="Concussion" description="The astral construct can manifest concussion blast (manifester level 7th) as a free action once per round." compset="RaceCustom">
     <fieldval field="trkMax" value="1"/>
     <usesource source="pPsiUn"/>
-    <tag group="AllowRCust" tag="MenuC"/>
+    <tag group="AllowRCust" tag="PUMenuC"/>
     <tag group="AbilType" tag="SpellLike"/>
     <tag group="Usage" tag="Round"/>
     <tag group="CustomCost" tag="4"/>
@@ -1787,12 +1859,12 @@ myVal +=3
     <usesource source="pPsiUn"/>
     <tag group="AbilType" tag="Extra"/>
     <tag group="CustomCost" tag="4"/>
-    <tag group="AllowRCust" tag="MenuC"/>
+    <tag group="AllowRCust" tag="PUMenuC"/>
     </thing>
   <thing id="rcMnuCDimS" name="Dimension Slide" description="The astral construct can manifest dimension slide (manifester level equal to Hit Dice) as a move action once per round." compset="RaceCustom">
     <fieldval field="trkMax" value="1"/>
     <usesource source="pPsiUn"/>
-    <tag group="AllowRCust" tag="MenuC"/>
+    <tag group="AllowRCust" tag="PUMenuC"/>
     <tag group="AbilType" tag="SpellLike"/>
     <tag group="Usage" tag="Round"/>
     <tag group="CustomCost" tag="4"/>
@@ -1801,7 +1873,7 @@ myVal +=3
   <thing id="rcMnuCEneB" name="Energy Bolt" description="The astral construct can manifest energy bolt (manifester level 8th) as a standard action once per round. The creator&apos;s active energy type determines the type of energy used. Kineticists are not restricted to an active energy type when choosing this menu option." compset="RaceCustom">
     <fieldval field="trkMax" value="1"/>
     <usesource source="pPsiUn"/>
-    <tag group="AllowRCust" tag="MenuC"/>
+    <tag group="AllowRCust" tag="PUMenuC"/>
     <tag group="AbilType" tag="SpellLike"/>
     <tag group="Usage" tag="Round"/>
     <tag group="CustomCost" tag="4"/>
@@ -1811,7 +1883,7 @@ myVal +=3
     <usesource source="pPsiUn"/>
     <tag group="AbilType" tag="Extra"/>
     <tag group="CustomCost" tag="4"/>
-    <tag group="AllowRCust" tag="MenuC"/>
+    <tag group="AllowRCust" tag="PUMenuC"/>
     <eval phase="Final">var myVal as number
 myVal = 0
 myVal = hero.childfound[xDamRdMag].field[abValue].value
@@ -1824,14 +1896,14 @@ myVal +=6
     <fieldval field="abValue" value="30"/>
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="4"/>
-    <tag group="AllowRCust" tag="MenuC"/>
+    <tag group="AllowRCust" tag="PUMenuC"/>
     <tag group="AbilType" tag="Extra"/>
     <eval phase="Final" priority="1000">herofield[tHP].value += field[abValue].value</eval>
     </thing>
   <thing id="rcMnuCInvi" name="Natural Invisibility" description="The astral construct is constantly invisible, even when attacking. This ability is inherent and not subject to the {i}invisibility purge{/i} spell." compset="RaceCustom">
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="4"/>
-    <tag group="AllowRCust" tag="MenuC"/>
+    <tag group="AllowRCust" tag="PUMenuC"/>
     <tag group="AbilType" tag="Super"/>
     </thing>
   <thing id="rcMnuCPRes" name="Power Resistance" description="You gain power resistance equal to 10 + 1/2 your Hit Dice." compset="RaceCustom" uniqueness="useronce">
@@ -1840,7 +1912,7 @@ myVal +=6
     <tag group="Helper" tag="SpecUp" name="SpecUp" abbrev="SpecUp"/>
     <tag group="RaReplace" tag="raAaDay" name="Daylight" abbrev="Daylight"/>
     <tag group="CustomCost" tag="4"/>
-    <tag group="AllowRCust" tag="MenuC"/>
+    <tag group="AllowRCust" tag="PUMenuC"/>
     <bootstrap thing="xPwrRes"></bootstrap>
     <eval phase="PostLevel" priority="10000"><![CDATA[
       doneif (tagis[Helper.SpcDisable] <> 0)
@@ -1853,13 +1925,13 @@ myVal +=6
   <thing id="rcMnuCRend" name="Rend" description="The astral construct makes claw attacks instead of slam attacks (it deals the same amount of damage as it would with its slam damage, but does slashing damage instead of bludgeoning damage). An astral construct that hits the same opponent with two claw attacks in the same round rends its foe, which deals extra damage equal to 2d6 + 1-1/2 times its Str modifier." compset="RaceCustom">
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="4"/>
-    <tag group="AllowRCust" tag="MenuC"/>
+    <tag group="AllowRCust" tag="PUMenuC"/>
     <tag group="AbilType" tag="Extra"/>
     </thing>
   <thing id="rcMnuCSpri" name="Spring Attack" description="The astral construct gains the Spring Attack feat." compset="RaceCustom">
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="4"/>
-    <tag group="AllowRCust" tag="MenuC"/>
+    <tag group="AllowRCust" tag="PUMenuC"/>
     <tag group="AbilType" tag="Extra"/>
     <bootstrap thing="fSpringAtt">
       <autotag group="thing" tag="skipprereq"/>
@@ -1868,7 +1940,7 @@ myVal +=6
   <thing id="rcMnuCWhir" name="Whirlwind Attack" description="The astral construct gains the Whirlwind Attack feat." compset="RaceCustom">
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="4"/>
-    <tag group="AllowRCust" tag="MenuC"/>
+    <tag group="AllowRCust" tag="PUMenuC"/>
     <tag group="AbilType" tag="Extra"/>
     <bootstrap thing="fWhirlwind">
       <autotag group="thing" tag="skipprereq"/>
@@ -3404,4 +3476,57 @@ doneif (tagis[Helper.SpcDisable] <> 0)
     <tag group="Helper" tag="ShowSpec"/>
     <tag group="ProductId" tag="HLCommunit"/>
     </thing>
+
+  <thing id="minPUAstC1" name="Astral Construct 1" description="Astral constructs are brought into being by the metacreativity power {i}astral construct{/i}. They are formed from raw ectoplasm (a portion of the astral medium drawn into the Material Plane). The power points spent by the construct’s creator during the manifestation of the power determine the level of the astral construct created. However, even astral constructs of the same level vary somewhat from each other, depending on the whims of their creators." compset="Minion" stacking="never">
+    <usesource source="pPsiUn"/>
+    <tag group="gType" tag="PUPsionics"/>
+    <tag group="gType" tag="PUAstrCons"/>
+    <tag group="Helper" tag="NoPathSoc"/>
+    <minion id="PUAstrCons">
+      <tag group="Hero" tag="FixedRace"/>
+      <bootstrap thing="rAstralC1"></bootstrap>
+      </minion>
+    </thing>
+  <thing id="minPUAstC2" name="Astral Construct 2" description="Astral constructs are brought into being by the metacreativity power {i}astral construct{/i}. They are formed from raw ectoplasm (a portion of the astral medium drawn into the Material Plane). The power points spent by the construct’s creator during the manifestation of the power determine the level of the astral construct created. However, even astral constructs of the same level vary somewhat from each other, depending on the whims of their creators." compset="Minion" stacking="never">
+    <usesource source="pPsiUn"/>
+    <tag group="gType" tag="PUPsionics"/>
+    <tag group="gType" tag="PUAstrCons"/>
+    <tag group="Helper" tag="NoPathSoc"/>
+    <minion id="PUAstrCons">
+      <tag group="Hero" tag="FixedRace"/>
+      <bootstrap thing="rAstralC2"></bootstrap>
+      </minion>
+    </thing>
+  <thing id="minPUAstC3" name="Astral Construct 3" description="Astral constructs are brought into being by the metacreativity power {i}astral construct{/i}. They are formed from raw ectoplasm (a portion of the astral medium drawn into the Material Plane). The power points spent by the construct’s creator during the manifestation of the power determine the level of the astral construct created. However, even astral constructs of the same level vary somewhat from each other, depending on the whims of their creators." compset="Minion" stacking="never">
+    <usesource source="pPsiUn"/>
+    <tag group="gType" tag="PUPsionics"/>
+    <tag group="gType" tag="PUAstrCons"/>
+    <tag group="Helper" tag="NoPathSoc"/>
+    <minion id="PUAstrCons">
+      <tag group="Hero" tag="FixedRace"/>
+      <bootstrap thing="rAstralC3"></bootstrap>
+      </minion>
+    </thing>
+  <thing id="minPUAstC4" name="Astral Construct 4" description="Astral constructs are brought into being by the metacreativity power {i}astral construct{/i}. They are formed from raw ectoplasm (a portion of the astral medium drawn into the Material Plane). The power points spent by the construct’s creator during the manifestation of the power determine the level of the astral construct created. However, even astral constructs of the same level vary somewhat from each other, depending on the whims of their creators." compset="Minion" stacking="never">
+    <usesource source="pPsiUn"/>
+    <tag group="gType" tag="PUPsionics"/>
+    <tag group="gType" tag="PUAstrCons"/>
+    <tag group="Helper" tag="NoPathSoc"/>
+    <minion id="PUAstrCons">
+      <tag group="Hero" tag="FixedRace"/>
+      <bootstrap thing="rAstralC4"></bootstrap>
+      </minion>
+    </thing>
+  <thing id="minPUAstC5" name="Astral Construct 5" description="Astral constructs are brought into being by the metacreativity power {i}astral construct{/i}. They are formed from raw ectoplasm (a portion of the astral medium drawn into the Material Plane). The power points spent by the construct’s creator during the manifestation of the power determine the level of the astral construct created. However, even astral constructs of the same level vary somewhat from each other, depending on the whims of their creators." compset="Minion" stacking="never">
+    <usesource source="pPsiUn"/>
+    <tag group="gType" tag="PUPsionics"/>
+    <tag group="gType" tag="PUAstrCons"/>
+    <tag group="Helper" tag="NoPathSoc"/>
+    <minion id="PUAstrCons">
+      <tag group="Hero" tag="FixedRace"/>
+      <bootstrap thing="rAstralC5"></bootstrap>
+      </minion>
+    </thing>
+
+
   </document>

--- a/COM_3PPPack_UltimatePsionics - Races Player.user
+++ b/COM_3PPPack_UltimatePsionics - Races Player.user
@@ -1415,8 +1415,8 @@ foreach pick in hero from BaseSkill where "Helper.SkCatPerf"
     <fieldval field="abValue" value="5"/>
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="1" name="1" abbrev="1"/>
-    <tag group="AbilType" tag="Extra" name="Extraordinary Ability" abbrev=" (Ex)"/>
-    <tag group="AllowRCust" tag="MenuA" name="Menu A" abbrev="Menu A"/>
+    <tag group="AbilType" tag="Extra"/>
+    <tag group="AllowRCust" tag="PUMenuA"/>
     <bootstrap thing="fDodge">
       <autotag group="thing" tag="skipprereq"/>
       </bootstrap>
@@ -1424,28 +1424,28 @@ foreach pick in hero from BaseSkill where "Helper.SkCatPerf"
   <thing id="rcMnuAPsiA" name="Psionic Attacks" description="The astral construct’s attacks are treated as psionic for the purposes of overcoming damage reduction." compset="RaceCustom" uniqueness="useronce">
     <fieldval field="abValue" value="5"/>
     <usesource source="pPsiUn"/>
-    <tag group="AllowRCust" tag="MenuA" name="Menu A" abbrev="Menu A"/>
+    <tag group="AllowRCust" tag="PUMenuA"/>
     <tag group="CustomCost" tag="1" name="1" abbrev="1"/>
     <tag group="AbilType" tag="Super"/>
     </thing>
   <thing id="rcMnuAMigh" name="Might" description="The astral construct’s melee attacks deal an additional +1 point of damage." compset="RaceCustom" uniqueness="useronce">
     <fieldval field="abValue" value="5"/>
     <usesource source="pPsiUn"/>
-    <tag group="AllowRCust" tag="MenuA" name="Menu A" abbrev="Menu A"/>
+    <tag group="AllowRCust" tag="PUMenuA"/>
     <tag group="CustomCost" tag="1" name="1" abbrev="1"/>
     <tag group="AbilType" tag="Extra"/>
     </thing>
   <thing id="rcMnuATalo" name="Talons" description="The astral construct replaces its slam attacks with claw attacks that deal either slashing or piercing damage, chosen at time of manifestation." compset="RaceCustom" uniqueness="useronce">
     <fieldval field="abValue" value="5"/>
     <usesource source="pPsiUn"/>
-    <tag group="AllowRCust" tag="MenuA" name="Menu A" abbrev="Menu A"/>
+    <tag group="AllowRCust" tag="PUMenuA"/>
     <tag group="CustomCost" tag="1" name="1" abbrev="1"/>
     <tag group="AbilType" tag="Extra"/>
     </thing>
   <thing id="rcMnuAUtil" name="Utility" description="Your construct can perform tasks for you. This can include such tasks as cleaning, cooking, or setting up camp, or any other activity that requires a DC 10 or lower skill check. An astral construct with this option does not need to stay close to the manifester and will continue following any given order until given other instructions. You can select this menu option multiple times. Each time, the DC of skill checks the construct can attempt increases by 2. An astral construct with this option that is not used in combat has a duration of 1 hour / level. If it later enters combat, its duration resets to 1 round / level, but suffers a -2 penalty to its attack rolls." compset="RaceCustom" uniqueness="useronce">
     <fieldval field="abValue" value="5"/>
     <usesource source="pPsiUn"/>
-    <tag group="AllowRCust" tag="MenuA" name="Menu A" abbrev="Menu A"/>
+    <tag group="AllowRCust" tag="PUMenuA"/>
     <tag group="CustomCost" tag="1" name="1" abbrev="1"/>
     <tag group="AbilType" tag="Extra"/>
     </thing>
@@ -1453,8 +1453,8 @@ foreach pick in hero from BaseSkill where "Helper.SkCatPerf"
     <fieldval field="abValue" value="5"/>
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="2"/>
-    <tag group="AbilType" tag="Extra" name="Extraordinary Ability" abbrev=" (Ex)"/>
-    <tag group="AllowRCust" tag="MenuB"/>
+    <tag group="AbilType" tag="Extra"/>
+    <tag group="AllowRCust" tag="PUMenuB"/>
     <bootstrap thing="fGreatClv">
       <autotag group="thing" tag="skipprereq"/>
       </bootstrap>
@@ -1463,22 +1463,22 @@ foreach pick in hero from BaseSkill where "Helper.SkCatPerf"
     <fieldval field="abValue" value="5"/>
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="2"/>
-    <tag group="AbilType" tag="Extra" name="Extraordinary Ability" abbrev=" (Ex)"/>
-    <tag group="AllowRCust" tag="MenuB"/>
+    <tag group="AbilType" tag="Extra"/>
+    <tag group="AllowRCust" tag="PUMenuB"/>
     </thing>
   <thing id="rcMnuBReac" name="Improved Might" description="The astral construct’s reach increases by 5 feet." compset="RaceCustom" uniqueness="useronce">
     <fieldval field="abValue" value="5"/>
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="2"/>
-    <tag group="AbilType" tag="Extra" name="Extraordinary Ability" abbrev=" (Ex)"/>
-    <tag group="AllowRCust" tag="MenuB"/>
+    <tag group="AbilType" tag="Extra"/>
+    <tag group="AllowRCust" tag="PUMenuB"/>
     </thing>
   <thing id="rcMnuBStuF" name="Stunning Fist" description="The astral construct gains the Stunning Fist feat even if it does not meet the [rerequisites. The construct can use Stunning Fist with its slam attack." compset="RaceCustom" uniqueness="useronce">
     <fieldval field="abValue" value="5"/>
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="2"/>
-    <tag group="AbilType" tag="Extra" name="Extraordinary Ability" abbrev=" (Ex)"/>
-    <tag group="AllowRCust" tag="MenuB"/>
+    <tag group="AbilType" tag="Extra"/>
+    <tag group="AllowRCust" tag="PUMenuB"/>
     <bootstrap thing="fStunFist">
       <autotag group="thing" tag="skipprereq"/>
       </bootstrap>
@@ -1487,15 +1487,15 @@ foreach pick in hero from BaseSkill where "Helper.SkCatPerf"
     <fieldval field="abValue" value="5"/>
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="4"/>
-    <tag group="AbilType" tag="Extra" name="Extraordinary Ability" abbrev=" (Ex)"/>
-    <tag group="AllowRCust" tag="MenuC"/>
+    <tag group="AbilType" tag="Extra"/>
+    <tag group="AllowRCust" tag="PUMenuC"/>
     </thing>
   <thing id="rcMnuCTaiS" name="Tail Slap" description="The astral construct gains a tail, giving it a tail slap secondary attack. A tail slap deals 2d8 points of damage." compset="RaceCustom" uniqueness="useronce">
     <fieldval field="abValue" value="5"/>
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="4"/>
-    <tag group="AbilType" tag="Extra" name="Extraordinary Ability" abbrev=" (Ex)"/>
-    <tag group="AllowRCust" tag="MenuC"/>
+    <tag group="AbilType" tag="Extra"/>
+    <tag group="AllowRCust" tag="PUMenuC"/>
     </thing>
   <thing id="rPUForgeB" name="Forgeborn" description="Believed to have been created centuries ago during a great war between psionic nations, the race of creatures referred to as the forgeborn were left to their own devices within the barren wasteland the war left behind.{br}{br}A hybridization of flesh and minerals, the forgeborn are varied in appearance and form, but were all created by merging psionically-empowered materials with the body of a humanoid to fashion a new creature.{br}{br}The race seeks out humanoids to transform in order to increase their numbers and some say resume the conflict for which they were created. Although little is known about the creation process by non-forgeborn, rumors say that they take those critically wounded in combat and repair their bodies, wiping the new forgeborn&apos;s memories and giving new life to the otherwise-fallen.{br}{br}Some darker rumors say that the race has learned not only how to alter the living, but potentially the recentlydeceased, but there has been little proof of this.{br}{br}Although they may appear as some sort of bizarre construct, the forgeborn are intelligent and capable of thought, emotion, and reasoning. While much of their time is spent working out combat strategies and ways to harness the psionic energy that powers their forms, they are avid students of history.{br}{br}Forgeborn benefit from longer lifespans than the human bodies that most of them were made from, but their inclination for combat means many never actually reach middle age. Among the forgeborn, such a fate is not mourned, for the fallen can sometimes be reclaimed and rebuilt into a new member of the race, resulting in a theology very similar to reincarnation." compset="Race">
     <fieldval field="rINT" value="2"/>
@@ -1707,8 +1707,8 @@ hero.child[svWill].field[Bonus].value += field[abValue].value]]></eval>
     <fieldval field="abValue" value="5"/>
     <usesource source="pPsiUn"/>
     <tag group="CustomCost" tag="1" name="1" abbrev="1"/>
-    <tag group="AbilType" tag="Extra" name="Extraordinary Ability" abbrev=" (Ex)"/>
-    <tag group="AllowRCust" tag="MenuA" name="Menu A" abbrev="Menu A"/>
+    <tag group="AbilType" tag="Extra"/>
+    <tag group="AllowRCust" tag="PUMenuA"/>
     </thing>
   <thing id="raPUNorFeE" name="Feral Erliss" description="While a noral bonding with an erliss typically results in improved mental abilities, sometimes it results in the noral taking on more feral aspects. A noral with this trait gains two claw attacks that deal 1d4 points of damage and gains a +2 racial bonus on Survival checks. This replaces gift of tongues and symbiotic resistance." compset="AltRaceTrt" uniqueness="unique">
     <usesource source="pPsiUn"/>

--- a/COM_3PPPack_UltimatePsionics - Tags.1st
+++ b/COM_3PPPack_UltimatePsionics - Tags.1st
@@ -10,6 +10,7 @@
     <value id="Race"        name="Psionic Race"/>
     <value id="PsiFocus"    name="Psionic Focus Always"/>
     <value id="FocusPick"   name="Psionic Focus Pick"/>
+    <value id="AstConMenu"  name="Astral Construct Menu"/>
   </group>
 
 <!-- ============================================== -->


### PR DESCRIPTION
* Ultimate Psionics (ShadowChemosh)

-Data Authoring File changes to support Astral Constructs better.
-Fixed #13. Boost Construct feat and "Summoner's Call" class ability is
now implemented and works.
-AllowRCust.MenuA, MenuB, MenuC changed to PUMenuA, PUMenuB and PUMenuB
to match community standards.
-Updated the XML to remove name/abbr info.
-Moved the creation of the tags to the Psionic Helper on the mechanic.
-Added a new racial ability to Astral Constructs to explain the Menu
choices.
-Updated the selection of Menu abilities to be more clear.

* Astral Construct fixes.

* Ultimate Psionics (ShadowChemosh)

-Data Authoring File changes to support Astral Constructs better.
-Fixed #13. Boost Construct feat and "Summoner's Call" class ability is
now implemented and works.
-AllowRCust.MenuA, MenuB, MenuC changed to PUMenuA, PUMenuB and PUMenuB
to match community standards.
-Updated the XML to remove name/abbr info.
-Moved the creation of the tags to the Psionic Helper on the mechanic.
-Added a new racial ability to Astral Constructs to explain the Menu
choices.
-Updated the selection of Menu abilities to be more clear.

* Astral Construct fixes.