### PR TITLE
Dynamic version of Suishen

### DIFF
--- a/COM_GMPack_AP050 - Night of Frozen Shadows.user
+++ b/COM_GMPack_AP050 - Night of Frozen Shadows.user
@@ -10,5 +10,85 @@
     <usesource source="CSLandLinn"/>
     <usesource source="PathJadeRe"/>
     <tag group="ProductId" tag="HLCommunit"/>
+  </thing>
+  <thing id="iSuishDyn" name="Suishen" description="{b}Alignment{/b} NG;\n{b}Ego{/b} 25\n{b}Senses{/b} 60 ft., darkvision, detect Amatatsu scions, read languages\n{b}Int{/b} 12; {b}Wis{/b} 16, {b}Cha{/b} 13\n{b}Communication{/b} speech, telepathy\n{b}Languages{/b} Common, Tien\n\n{i}Suishen{/i} is a {i}+2 defending flaming katana{/i} (see page 27). The ancestral blade of the Amatatsu family, {i}Suishen{/i} is believed to contain the soul of the first Amatatsu emperor of Minkai. It has been passed down through generations of the family, serving as advisor and spiritual guide. It was actually {i}Suishen{/i}&apos;s idea to be sold to Fynn Snaevald in order to save the family line.\n\n{i}Suishen{/i} can detect any scion of the Amatatsu family within 60 feet, whether a natural-born descendant or a person invested with the right to rule as an Amatatsu (such as a creature marked by the {i}Amatatsu Seal{/i}). Although {i}Suishen{/i} is neutral good, any Amatatsu scion, regardless of alignment, can wield the sword without gaining a negative level. This boon is at {i}Suishen{/i}&apos;s discretion, however, and should such a scion ever betray the family or prove unworthy as an heir, the sword can reinstate this penalty and cause a personality conflict. Even though {i}Suishen{/i} can likely dominate anyone who tries to wield it, the sword usually acquiesces to the wishes of its wielder, provided she is a rightful Amatatsu scion - though after 50 years of holding its silence, {i}Suishen{/i} is a bit rough as a conversationalist, communicating in a very gruff, no-nonsense manner.\n\n{i}Suishen{/i} has a number of additional abilities as well, though it reveals these powers to its wielder only after she has shown herself honorable and worthy of bearing the family&apos;s heirloom blade. Each time {i}Suishen{/i}&apos;s wielder is involved in a fight in which an oni of the Five Storms (such as Kimandatsu) is killed, the wielder is made aware of one new power in the following order. If a new person wields {i}Suishen{/i}, that person must learn the sword&apos;s additional powers all over again.\n• {i}Resist energy{/i} (cold) 3/day becomes {i}protection from energy{/i} (cold) at will.\n• {i}Suishen{/i} gains the {i}flaming burst{/i} ability.\n• {i}Invisibility purge{/i} at will.\n• {i}Suishen{/i} gains the {i}bane{/i} ability against creatures with the oni subtype.\n\n{b}Destruction{/b}\n{i}Suishen{/i} is destroyed if the blade is used to slay the last Amatatsu scion." compset="MagicWep">
+    <fieldval field="iCL" value="20"/>
+    <fieldval field="BonEnhance" value="2"/>
+    <fieldval field="shortname" value="Suishen"/>
+    <fieldval field="actUserMin" value="0"/>
+    <fieldval field="actUserMax" value="4"/>
+    <fieldval field="actName" value="Oni defeated"/>
+    <fieldval field="actIncrNam" value="Oni Defeated"/>
+    <usesource source="PathJadeRe" parent="PathAdvent" name="Jade Regent"/>
+    <tag group="Helper" tag="UserAdjust"/>
+    <tag group="Helper" tag="ArtiMinor" name="Artifact (Minor)" abbrev="Artifact"/>
+    <tag group="User" tag="Activation"/>
+    <tag group="User" tag="HideActChk"/>
+    <tag group="User" tag="NoActSign"/>
+    <tag group="iSchool" tag="Evocation" name="Evocation" abbrev="Evoc"/>
+    <tag group="Helper" tag="EquipAvail" name="EquipAvail" abbrev="EquipAvail"/>
+    <tag group="Helper" tag="ShowSpec"/>
+    <tag group="ProductId" tag="HLCommunit"/>
+    <bootstrap thing="spSeeInv2">
+      <autotag group="Helper" tag="ItemSpell"/>
+      <autotag group="Usage" tag="Day"/>
+      <assignval field="trkMax" value="3"/>
+      <assignval field="sCL" value="20"/>
+      </bootstrap>
+    <bootstrap thing="spEnduEle1">
+      <autotag group="Helper" tag="ItemSpell"/>
+      <autotag group="Usage" tag="Constant"/>
+      <assignval field="sCL" value="20"/>
+      </bootstrap>
+    <bootstrap thing="spAirWal4">
+      <autotag group="Helper" tag="ItemSpell"/>
+      <autotag group="Usage" tag="Day"/>
+      <assignval field="trkMax" value="3"/>
+      <assignval field="sCL" value="20"/>
+      </bootstrap>
+    <bootstrap thing="spDayligh3">
+      <autotag group="Helper" tag="ItemSpell"/>
+      <autotag group="Usage" tag="Day"/>
+      <assignval field="trkMax" value="3"/>
+      <assignval field="sCL" value="20"/>
+      </bootstrap>
+    <bootstrap thing="spProtfro3">
+      <containerreq phase="First" priority="251"><![CDATA[fieldval:actUser >= 1]]></containerreq>
+      <autotag group="Usage" tag="AtWill"/>
+      <autotag group="Helper" tag="ItemSpell"/>
+      <assignval field="livename" value="Protection from Energy (cold)"/>
+      <assignval field="sCL" value="20"/>
+      </bootstrap>
+    <bootstrap thing="spInviPur3">
+      <containerreq phase="First" priority="254"><![CDATA[fieldval:actUser >= 3]]></containerreq>
+      <autotag group="Helper" tag="ItemSpell"/>
+      <autotag group="Usage" tag="AtWill"/>
+      <assignval field="sCL" value="20"/>
+      </bootstrap>
+    <bootstrap thing="spResiEne2">
+      <containerreq phase="First" priority="250">fieldval:actUser = 0</containerreq>
+      <autotag group="Usage" tag="Day"/>
+      <autotag group="Helper" tag="ItemSpell"/>
+      <assignval field="trkMax" value="3"/>
+      <assignval field="livename" value="Resist Energy (cold)"/>
+      <assignval field="sCL" value="20"/>
+      </bootstrap>
+    <eval phase="First"><![CDATA[      doneif (field[actUser].value < 4)
+
+field[actName2].text = "Vs. Oni"]]></eval>
+    <eval phase="PreLevel" priority="1000" index="2"><![CDATA[doneif (field[abilAct2].value = 0)
+
+        #extradamage[this," plus 2d6 vs. Oni",field[thingname].text]
+        field[Bonus].value += 2]]></eval>
+    <child entity="wSpecMagic">
+      <bootstrap thing="wKatana"></bootstrap>
+      <bootstrap thing="iDefend"></bootstrap>
+      <bootstrap thing="iFlaming">
+        <containerreq phase="First" priority="252"><![CDATA[fieldval:actUser < 2]]></containerreq>
+        </bootstrap>
+      <bootstrap thing="iFlamBurst">
+        <containerreq phase="First" priority="253"><![CDATA[fieldval:actUser >= 2]]></containerreq>
+        </bootstrap>
+      </child>
     </thing>
   </document>


### PR DESCRIPTION
Separate version of the Adventure Path artifact Suishen. Allows the weapon spells and abilities to update based on abilAct field (counter from 0-4).